### PR TITLE
Add dataframe transformers to assert_df_equality

### DIFF
--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -3,14 +3,16 @@ from chispa.bcolors import *
 from chispa.schema_comparer import assert_schema_equality, assert_schema_equality_ignore_nullable, are_schemas_equal_ignore_nullable
 from chispa.row_comparer import are_rows_approx_equal
 import chispa.six as six
-
+from functools import reduce
 
 class DataFramesNotEqualError(Exception):
    """The DataFrames are not equal"""
    pass
 
 
-def assert_df_equality(df1, df2, ignore_nullable = False):
+def assert_df_equality(df1, df2, ignore_nullable = False, transforms=[]):
+    df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
+    df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
     s1 = df1.schema
     s2 = df2.schema
     if ignore_nullable:

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -16,6 +16,26 @@ def describe_assert_column_equality():
             assert_df_equality(df1, df2)
 
 
+    def it_throws_with_schema_column_order_mismatch():
+        data1 = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data1, ["num", "name"])
+        data2 = [("jose", 1), ("li", 1)]
+        df2 = spark.createDataFrame(data2, ["name", "num"])
+        with pytest.raises(SchemasNotEqualError) as e_info:
+            assert_df_equality(df1, df2)
+
+
+    def it_does_not_throw_on_schema_column_order_mismatch_with_transforms():
+        data1 = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [("jose", 1), ("li", 1)]
+        df2 = spark.createDataFrame(data2, ["name", "num"])
+        with pytest.raises(SchemasNotEqualError) as e_info:
+            assert_df_equality(df1, df2, transforms=[
+                lambda df: df.select(sorted(df.columns))
+            ])
+
+
     def it_throws_with_content_mismatches():
         data1 = [("jose", "jose"), ("li", "li"), ("luisa", "laura")]
         df1 = spark.createDataFrame(data1, ["name", "expected_name"])


### PR DESCRIPTION
Adding the capability to add dataframe transformers to the assert_df_equality method. This helps take care of a few use cases such as :
1. Sorting of columns before comparing the schema
2. Conversion of columns from Integer type to Long so that a test dataframe loaded from csv can be compared against actual

Thanks for building chispa! 