### PR TITLE
try to use findspark to find PySpark installation

### DIFF
--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -1,3 +1,29 @@
+import sys
+import os
+from glob import glob
+
+# Add PySpark to the library path based on the value of SPARK_HOME if pyspark is not already in our path
+try:
+    from pyspark import context
+except ImportError:
+    # We need to add PySpark, try use findspark, or failback to the "manually" find it
+    try:
+        import findspark
+        findspark.init()
+    except ImportError:
+        try:
+            spark_home = os.environ['SPARK_HOME']
+            sys.path.append(os.path.join(spark_home, 'python'))
+            py4j_src_zip = glob(os.path.join(spark_home, 'python', 'lib', 'py4j-*-src.zip'))
+            if len(py4j_src_zip) == 0:
+                raise ValueError('py4j source archive not found in %s'
+                                 % os.path.join(spark_home, 'python', 'lib'))
+            else:
+                py4j_src_zip = sorted(py4j_src_zip)[::-1]
+                sys.path.append(py4j_src_zip[0])
+        except KeyError:
+            print("Can't find Apache Spark. Please set environment variable SPARK_HOME to root of installation!")
+            exit(-1)
+
 from .dataframe_comparer import DataFramesNotEqualError, assert_df_equality, assert_approx_df_equality
 from .column_comparer import ColumnsNotEqualError, assert_column_equality, assert_approx_column_equality
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "findspark"
+version = "1.4.2"
+description = "Find pyspark to make it importable."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "py"
 version = "1.4.34"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -24,7 +32,7 @@ python-versions = "*"
 
 [[package]]
 name = "pyspark"
-version = "3.0.1"
+version = "3.0.2"
 description = "Apache Spark Python API"
 category = "dev"
 optional = false
@@ -64,12 +72,16 @@ pytest = ">=2.6.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">2.7"
-content-hash = "d64bd400fa674665f1babb3dc6f50b5a5bb3e69b7c7b3a73507ec731f2778c3b"
+content-hash = "e888a725f6eb21703e2161d14026ba97594ec29b67a07583d05e94a137c97456"
 
 [metadata.files]
 colorama = [
     {file = "colorama-0.3.9-py2.py3-none-any.whl", hash = "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda"},
     {file = "colorama-0.3.9.tar.gz", hash = "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"},
+]
+findspark = [
+    {file = "findspark-1.4.2-py2.py3-none-any.whl", hash = "sha256:4eeb6d831b28cb869da8f4f1a24eb7ff1b51f11c17e44a713fedc9556ab2ccfe"},
+    {file = "findspark-1.4.2.tar.gz", hash = "sha256:6d52971f4417e976aea21aea0f4ac7e470fa365d6139100e03fb76b76eb97da0"},
 ]
 py = [
     {file = "py-1.4.34-py2.py3-none-any.whl", hash = "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a"},
@@ -80,7 +92,7 @@ py4j = [
     {file = "py4j-0.10.9.tar.gz", hash = "sha256:36ec57f43ff8ced260a18aa9a4e46c3500a730cac8860e259cbaa546c2b9db2f"},
 ]
 pyspark = [
-    {file = "pyspark-3.0.1.tar.gz", hash = "sha256:38b485d3634a86c9a2923c39c8f08f003fdd0e0a3d7f07114b2fb4392ce60479"},
+    {file = "pyspark-3.0.2.tar.gz", hash = "sha256:d4f2ced43394ad773f7b516a4bbcb5821a940462a17b1a25f175c83771b62ebc"},
 ]
 pytest = [
     {file = "pytest-3.2.2-py2.py3-none-any.whl", hash = "sha256:b84f554f8ddc23add65c411bf112b2d88e2489fd45f753b1cae5936358bdf314"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = ">2.7"
 pytest = "3.2.2"
 pytest_describe = "^1.0.0"
 pyspark = ">2.0.0"
+findspark = "1.4.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
if `findspark` isn't installed, then fallback to the "manual" setup by looking into `SPARK_HOME`. I deliberately didn't put `findspark` as required dependency, although we can move it there...