### PR TITLE
Allow user to specify columns to sort DFs

### DIFF
--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -16,8 +16,10 @@ def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_n
         transforms = []
     if ignore_column_order:
         transforms.append(lambda df: df.select(sorted(df.columns)))
-    if ignore_row_order:
+    if ignore_row_order is True:
         transforms.append(lambda df: df.sort(df.columns))
+    elif ignore_row_order:
+        transforms.append(lambda df: df.sort(ignore_row_order))
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
     assert_schema_equality(df1.schema, df2.schema, ignore_nullable)

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from spark import *
+from pyspark.sql.utils import AnalysisException
 from chispa import *
 from chispa.dataframe_comparer import are_dfs_equal
 from chispa.schema_comparer import SchemasNotEqualError
@@ -38,6 +39,16 @@ def describe_assert_df_equality():
         data2 = [("li", 2), ("jose", 1)]
         df2 = spark.createDataFrame(data2, ["name", "num"])
         assert_df_equality(df1, df2, ignore_row_order=True, ignore_column_order=True)
+
+
+    def it_can_work_with_different_row_orders_and_unsortable_columns():
+        df1 = spark.createDataFrame([(1,{"a": 1}), (2,{"a": 1}), (3,{"a": 1})],
+                ["sort_me", "cant_sort"])
+        df2 = spark.createDataFrame([(2,{"a": 1}), (1,{"a": 1}), (3,{"a": 1})],
+                ["sort_me", "cant_sort"])
+        with pytest.raises(AnalysisException):
+            assert_df_equality(df1, df2, ignore_row_order=True)
+        assert_df_equality(df1, df2, ignore_row_order=["sort_me"])
 
 
     def it_raises_for_row_insensitive_with_diff_content():


### PR DESCRIPTION
I'm trying to compare DFs where the order doesn't matter, but the DF contains a Struct column with a schema something like so: `struct<tags:struct<create:array<struct<primary:boolean,more_fields:string>>>>`.  If I try to `ignore_row_order=True`, I get an exception because my struct can't be sorted, which is reasonable given my gross data.

I feel it's an ugly API, but this PR introduces an alternative syntax: `ignore_row_order=["keys", "to", "sort"]`, as seen in the new test:
```python
    def it_can_work_with_different_row_orders_and_unsortable_columns():
        df1 = spark.createDataFrame([(1,{"a": 1}), (2,{"a": 1}), (3,{"a": 1})],
                ["sort_me", "cant_sort"])
        df2 = spark.createDataFrame([(2,{"a": 1}), (1,{"a": 1}), (3,{"a": 1})],
                ["sort_me", "cant_sort"])
        with pytest.raises(AnalysisException):
            assert_df_equality(df1, df2, ignore_row_order=True)
        assert_df_equality(df1, df2, ignore_row_order=["sort_me"])
```

The original `ignore_row_order=True` still works too, but I broke using other truthy values for `ignore_row_order`.