### PR TITLE
Add ignore_columns to assert_df_equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,19 @@ You can ignore the nullable property when assessing equality by adding a flag:
 assert_df_equality(df1, df2, ignore_nullable=True)
 ```
 
+### Ignore a column
+
+Sometimes you may wish to compare only a subset of the columns in your DataFrame.  You can specify
+the columns to exclude from comparison with a flag:
+
+```python
+data1 = [("apple", {"fruit": True}), ("carrot", {"fruit": False})]
+df1 = spark.createDataFrame(data1, ["name", "properties"])
+data2 = [("apple", {"veg": False}), ("carrot", {"veg": True})]
+df2 = spark.createDataFrame(data2, ["name", "properties"])
+assert_df_equality(df1, df2, ignore_columns=["properties"])
+```
+
 ### Allow NaN equality
 
 Python has NaN (not a number) values and two NaN values are not considered equal by default.  Create two NaN values, compare them, and confirm they're not considered equal by default.

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -11,9 +11,11 @@ class DataFramesNotEqualError(Exception):
    pass
 
 
-def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False, ignore_column_order=False, ignore_row_order=False):
+def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False, ignore_column_order=False, ignore_row_order=False, ignore_columns=False):
     if transforms is None:
         transforms = []
+    if ignore_columns:
+        transforms.append(lambda df: df.drop(*ignore_columns))
     if ignore_column_order:
         transforms.append(lambda df: df.select(sorted(df.columns)))
     if ignore_row_order:

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -112,6 +112,14 @@ def describe_assert_df_equality():
             assert_df_equality(df1, df2, allow_nan_equality=False)
 
 
+    def it_can_ignore_order_and_columns():
+        data1 = [("apple", {"fruit": True}), ("carrot", {"fruit": False})]
+        df1 = spark.createDataFrame(data1, ["name", "properties"])
+        data2 = [("carrot", {"veg": True}), ("apple", {"veg": False})]
+        df2 = spark.createDataFrame(data2, ["name", "properties"])
+        assert_df_equality(df1, df2, ignore_row_order=True, ignore_columns=["properties"])
+
+
 def describe_are_dfs_equal():
     def it_returns_false_with_schema_mismatches():
         data1 = [(1, "jose"), (2, "li"), (3, "laura")]

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -114,6 +114,14 @@ def describe_dataframe_equality():
         assert_df_equality(df1, df2, ignore_nullable=True)
 
 
+    def ignore_a_column():
+        data1 = [("apple", {"fruit": True}), ("carrot", {"fruit": False})]
+        df1 = spark.createDataFrame(data1, ["name", "properties"])
+        data2 = [("apple", {"veg": False}), ("carrot", {"veg": True})]
+        df2 = spark.createDataFrame(data2, ["name", "properties"])
+        assert_df_equality(df1, df2, ignore_columns=["properties"])
+
+
     def consider_nan_values_equal():
         data1 = [(float('nan'), "jose"), (2.0, "li")]
         df1 = spark.createDataFrame(data1, ["num", "name"])


### PR DESCRIPTION
I'm trying to compare DFs where the order doesn't matter, but the DF contains a Struct column with a schema something like so: `struct<tags:struct<create:array<struct<primary:boolean,more_fields:string>>>>`. If I try to `ignore_row_order=True`, I get an exception because my struct can't be sorted, which is reasonable given my gross data.

I opened https://github.com/MrPowers/chispa/pull/23, but I don't think that other users would need that functionality.

This PR instead adds a new `ignore_columns` feature to `assert_df_equality`, which covers my use case and is hopefully useable for other folks as well.