### PR TITLE
I25/ignore nullable handles arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,23 @@ You can ignore the nullable property when assessing equality by adding a flag:
 assert_df_equality(df1, df2, ignore_nullable=True)
 ```
 
+Elements contained within an `ArrayType()` also have a nullable property, in addition to the nullable property of the column schema. These are also ignored when passing `ignore_nullable=True`.
+
+Again, examine the following code to understand the error that `ignore_nullable=True` bypasses:
+
+```python
+def ignore_nullable_property_array():
+    s1 = StructType([
+        StructField("name", StringType(), True),
+        StructField("coords", ArrayType(DoubleType(), True), True),])
+    df1 = spark.createDataFrame([("juan", [1.42, 3.5]), ("bruna", [2.76, 3.2])], s1)
+    s2 = StructType([
+        StructField("name", StringType(), True),
+        StructField("coords", ArrayType(DoubleType(), False), True),])
+    df2 = spark.createDataFrame([("juan", [1.42, 3.5]), ("bruna", [2.76, 3.2])], s2)
+    assert_df_equality(df1, df2)
+```
+
 ### Allow NaN equality
 
 Python has NaN (not a number) values and two NaN values are not considered equal by default.  Create two NaN values, compare them, and confirm they're not considered equal by default.

--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -45,7 +45,24 @@ def are_schemas_equal_ignore_nullable(s1, s2):
         return False
     zipped = list(six.moves.zip_longest(s1, s2))
     for sf1, sf2 in zipped:
-        if sf1.name != sf2.name or sf1.dataType != sf2.dataType:
+        names_equal = sf1.name == sf2.name
+        types_equal = check_type_equal_ignore_nullable(sf1, sf2)
+        if not names_equal or not types_equal:
           return False
     return True
 
+
+def check_type_equal_ignore_nullable(sf1, sf2):
+    """Checks StructField data types ignoring nullables.
+
+    Handles array element types also.
+    """
+    dt1, dt2 = sf1.dataType, sf2.dataType
+    if dt1.typeName() == dt2.typeName():
+        # Account for array types by inspecting elementType.
+        if dt1.typeName() == 'array':
+            return dt1.elementType == dt2.elementType
+        else:
+            return True
+    else:
+        return False

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -114,6 +114,18 @@ def describe_dataframe_equality():
         assert_df_equality(df1, df2, ignore_nullable=True)
 
 
+    def ignore_nullable_property_array():
+        s1 = StructType([
+           StructField("name", StringType(), True),
+           StructField("coords", ArrayType(DoubleType(), True), True),])
+        df1 = spark.createDataFrame([("juan", [1.42, 3.5]), ("bruna", [2.76, 3.2])], s1)
+        s2 = StructType([
+           StructField("name", StringType(), True),
+           StructField("coords", ArrayType(DoubleType(), False), True),])
+        df2 = spark.createDataFrame([("juan", [1.42, 3.5]), ("bruna", [2.76, 3.2])], s2)
+        assert_df_equality(df1, df2, ignore_nullable=True)
+
+
     def consider_nan_values_equal():
         data1 = [(float('nan'), "jose"), (2.0, "li")]
         df1 = spark.createDataFrame(data1, ["num", "name"])

--- a/tests/test_schema_comparer.py
+++ b/tests/test_schema_comparer.py
@@ -77,11 +77,27 @@ def describe_are_schemas_equal_ignore_nullable():
     def it_returns_true_when_only_nullable_flag_is_different():
         s1 = StructType([
            StructField("name", StringType(), True),
-           StructField("age", IntegerType(), True)])
+           StructField("age", IntegerType(), True),
+           StructField("coords", ArrayType(DoubleType(), True), True),
+        ])
         s2 = StructType([
            StructField("name", StringType(), True),
-           StructField("age", IntegerType(), False)])
+           StructField("age", IntegerType(), False),
+           StructField("coords", ArrayType(DoubleType(), True), False),
+        ])
         assert are_schemas_equal_ignore_nullable(s1, s2) == True
+
+
+    def it_returns_true_when_only_nullable_flag_is_different_within_array_element():
+        s1 = StructType([StructField("coords", ArrayType(DoubleType(), True), True)])
+        s2 = StructType([StructField("coords", ArrayType(DoubleType(), False), True)])
+        assert are_schemas_equal_ignore_nullable(s1, s2) == True
+
+
+    def it_returns_false_when_the_element_type_is_different_within_array():
+        s1 = StructType([StructField("coords", ArrayType(DoubleType(), True), True)])
+        s2 = StructType([StructField("coords", ArrayType(IntegerType(), True), True)])
+        assert are_schemas_equal_ignore_nullable(s1, s2) == False
 
 
     def it_returns_false_when_column_names_differ():

--- a/tests/test_schema_comparer.py
+++ b/tests/test_schema_comparer.py
@@ -108,3 +108,16 @@ def describe_are_schemas_equal_ignore_nullable():
            StructField("name", StringType(), True),
            StructField("age", IntegerType(), False)])
         assert are_schemas_equal_ignore_nullable(s1, s2) == False
+
+
+def describe_are_structfield_types_equal_ignore_nullable():
+    def it_returns_true_when_only_nullable_flag_is_different_within_array_element():
+        s1 = StructField("coords", ArrayType(DoubleType(), True), True)
+        s2 = StructField("coords", ArrayType(DoubleType(), False), True)
+        assert check_type_equal_ignore_nullable(s1, s2) == True
+
+
+    def it_returns_false_when_the_element_type_is_different_within_array():
+        s1 = StructField("coords", ArrayType(DoubleType(), True), True)
+        s2 = StructField("coords", ArrayType(IntegerType(), True), True)
+        assert check_type_equal_ignore_nullable(s1, s2) == False


### PR DESCRIPTION
Added support for ignoring the nullable flag for `ArrayType()` elements by creating a new function in `schema_comparer.py`.

Can you check you're OK with the test cases? I did the bottom two tests as a separate commit as I felt they might duplicate existing tests. Let me know if you think they add value or not.

I also had a go at updating the README, with a new example. Let me know if you want it reworded or changed.

Cheers!

Closes #25 