### PR TITLE
build: change build-backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,5 @@ pyspark = ">2.0.0"
 findspark = "1.4.2"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This changes the build backend to `poetry-core`[^1].

> intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects

[^1]: https://github.com/python-poetry/poetry-core