### PR TITLE
Feature/dataframe generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,310 @@ Here's the error message:
 
 ![SchemasNotEqualError](https://github.com/MrPowers/chispa/blob/main/images/schemas_not_approx_equal.png)
 
+## DataFrame Generator
+
+This module lets you create DataFrames, according to a schema, with fake synthetic data (using Faker) so that 
+you can either use it in your tests or make use of property based testing (explained further down).
+
+The starting point is the DataFrameGenerator data class, and it can be created by doing the following:
+
+```python
+df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema)
+```
+
+Where the schema is a StructType object like the following:
+
+```python
+schema: StructType = StructType([
+    StructField("expected_name", StringType(), True),
+    StructField("int", IntegerType(), True),
+    StructField("long", LongType(), True),
+    StructField("byte", ByteType(), True),
+    StructField("short", ShortType(), True),
+    StructField("double", DoubleType(), True),
+    StructField("float", FloatType(), True),
+    StructField("decimal", DecimalType(), True),
+    StructField("bool", BooleanType(), True),
+    StructField("binary", BinaryType(), True),
+    StructField("date", DateType(), True),
+    StructField("timestamp", TimestampType(), True)
+])
+```
+
+Those are the supported types right now, each of those types has a matching Faker provider in the `DEFAULT_CONFIG` dictionary:
+
+```python
+DEFAULT_CONFIG: dict = {
+    "StringType": {"provider": "pystr"},
+    "ByteType": {"provider": "pyint", "kwargs": {"min_value": -128, "max_value": 127}},
+    "ShortType": {"provider": "pyint", "kwargs": {"min_value": -32768, "max_value": 32767}},
+    "IntegerType": {"provider": "pyint", "kwargs": {"min_value": -2147483648, "max_value": 2147483647}},
+    "LongType": {"provider": "pyint", "kwargs": {"min_value": -9223372036854775808, "max_value": 9223372036854775807}},
+    "DoubleType": {"provider": "pyfloat"},
+    "FloatType": {"provider": "pyfloat"},
+    "DecimalType(10,0)": {"provider": "pydecimal", "kwargs": {"left_digits": 10, "right_digits": 0}},
+    "DateType": {"provider": "date_object"},
+    "TimestampType": {"provider": "date_time"},
+    "BooleanType": {"provider": "pybool"},
+    "BinaryType": {"provider": "binary", "kwargs": {"length": 64}}
+}
+```
+
+Calling the method `arbitrary_dataframes` from the DataFrameGenerator will give you a Python generator of 
+DataFrames (default is 10 DataFrames) with rows filled with fake data (default is 10 rows).
+
+For instance, the following code:
+
+```python
+schema: StructType = StructType([
+    StructField("string", StringType(), True),
+    StructField("int", IntegerType(), True),
+    StructField("date", DateType(), True)
+])
+df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema)
+for df in df_gen.arbitrary_dataframes():
+    df.show()
+```
+
+will result in:
+
+```shell
++--------------------+-----------+----------+
+|              string|        int|      date|
++--------------------+-----------+----------+
+|athKDRmDyDoOFTtMyEpS|  208977570|1998-10-05|
+|KsiKWhuWhrxwjIfZObWE|   36536111|2009-02-07|
+|yBnbHFvtUaMITurvzgGa|-1150452234|1975-06-04|
+|hJgwshOrnGuOVYSHiQvT| -394148922|1996-09-03|
+|RRwPfXMSXfwPTpEbCCYd|-2126030849|2020-11-01|
+|NxjZLvalBmUxlHCCdvRS| -868167137|2017-01-09|
+|OCKxJFjEWnXFLTnmxlAL|  378510418|2004-09-08|
+|FcPQoSKsaWtkVAtsHtmE|-1778979182|1976-06-08|
+|gGLrGwLlHQUJgqLoHscd|-1707952693|1975-07-04|
+|OQfOJfUAqYMdoDKyIODt| 2042919219|1974-08-18|
++--------------------+-----------+----------+
+
++--------------------+-----------+----------+
+|              string|        int|      date|
++--------------------+-----------+----------+
+|YdBiqoUTPchuiVVCToYb|  837577396|2011-10-20|
+|ENUTmYcJbIlAHXdXrlcK| 1965683018|1999-06-11|
+|qkYABZaLxKSTSKULvJUn|-1534538904|2007-07-21|
+|IBekMJxdILbHrseyELjI| -778855686|1995-02-21|
+|eOeDuqcyQrmMKyHsdIqi| 2062228449|2021-04-24|
+|gvdnhvZEWHxjdVOCNVNO|  634606029|1988-07-28|
+|XPooEkKLCsdDBBDPBxdw| 1147520365|2010-10-26|
+|QuyvBSnhmNDFViNtZloD| -615531044|1988-11-11|
+|wfNVuyjNwLOlIMILwEyY|    -438993|1998-05-08|
+|vGqmOojchnEBiFUrIyEF|-1961143065|1995-10-13|
++--------------------+-----------+----------+
+.
+.
+.
+```
+
+You can also make use of the `seed` parameter to always get the same results, could be beneficial in some test cases.
+
+And, more importantly, you can make use of the `config` parameter to make sure the fake data in the DataFrames is as close 
+to the actual data you use.
+
+For instance, the following:
+
+```python
+schema: StructType = StructType([
+    StructField("bank_account_number", StringType(), True),
+    StructField("string", StringType(), True)
+])
+
+config: dict = {
+    "string": {
+        "data_type": StringType(),
+        "provider": "random_element",
+        "kwargs": {
+            "elements": ('x', 'y')
+        },
+    },
+    "bank_account_number": {
+        "data_type": StringType(),
+        "provider": "iban",
+    }
+}
+
+df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema, config=config)
+for df in df_gen.arbitrary_dataframes():
+    df.show(truncate=False)
+```
+
+will result in:
+
+```shell
++----------------------+------+
+|bank_account_number   |string|
++----------------------+------+
+|GB05ZPOQ53062662223126|x     |
+|GB30FBEP02205427369768|y     |
+|GB77ZVZD72401097292467|y     |
+|GB37ZAUF42921111575037|x     |
+|GB94YOYW99106454150303|x     |
+|GB45AHZD58341571053644|y     |
+|GB49NIWO23000421077097|y     |
+|GB57KKMR90126850543238|x     |
+|GB36MJSE75788716032200|y     |
+|GB09WQRG06056962875254|x     |
++----------------------+------+
+
++----------------------+------+
+|bank_account_number   |string|
++----------------------+------+
+|GB05DOHQ75315263055315|x     |
+|GB97WKAZ86167865050998|x     |
+|GB74FNSZ74818713531062|y     |
+|GB09RNUK49954795362800|x     |
+|GB52EKEI43974684705487|y     |
+|GB71CMIO65098526908411|y     |
+|GB21FRNR40256327200553|y     |
+|GB78TPWY70848987416423|x     |
+|GB72FOTB13893525853918|x     |
+|GB88ZPWG41923933222632|y     |
++----------------------+------+
+.
+.
+.
+```
+
+The other useful functionality of the DataFrameGenerator is that it can have a transformer function applied to the DataFrames,
+perhaps you have a certain transformation that you would like to run over your DataFrame, if so you can pass this function to
+the DataFrameGenerator, and it will then run it over the DataFrames and the iterator returned from the `arbitrary_dataframes`
+method will now be DataFrames with that transformation applied.
+
+For instance, the following:
+
+```python
+schema: StructType = StructType([
+    StructField("string", StringType(), True),
+    StructField("number1", IntegerType(), True),
+    StructField("number2", IntegerType(), True),
+])
+
+def transformation(df: DataFrame) -> DataFrame:
+    return df.withColumn("number_sum", col("number1") + col("number2")).limit(2)
+
+df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema, transformer=transformation)
+for df in df_gen.arbitrary_dataframes():
+    df.show(truncate=False)
+```
+
+of course, a simple transformation can be in lambda form as well:
+
+```python
+df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema, transformer=lambda df: df.withColumn("number_sum", col("number1") + col("number2")).limit(2))
+```
+
+
+
+will result in:
+
+```shell
++--------------------+-----------+----------+----------+
+|string              |number1    |number2   |number_sum|
++--------------------+-----------+----------+----------+
+|hfvXIxpHYWmeozQCgDdb|-404644089 |1391745093|987101004 |
+|JMeuXcnlUBMabyYkckdL|-1019120536|1893116782|873996246 |
++--------------------+-----------+----------+----------+
+
++--------------------+-----------+-----------+----------+
+|string              |number1    |number2    |number_sum|
++--------------------+-----------+-----------+----------+
+|IuGgFufcEWilkamohglP|-1867212230|-1935661407|492093659 |
+|rhsttgaKKcWcMVRCSGIk|1412079017 |16007381   |1428086398|
++--------------------+-----------+-----------+----------+
+
++--------------------+-----------+-----------+-----------+
+|string              |number1    |number2    |number_sum |
++--------------------+-----------+-----------+-----------+
+|RmihqKGAtoNxmofMNLms|-1729443426|377528902  |-1351914524|
+|ZFScHJstlfOpJlvFFKmT|-2142767718|-1554653988|597545590  |
++--------------------+-----------+-----------+-----------+
+.
+.
+.
+```
+
+## Property Based Testing Approach
+
+Although far from mature, the code here is a good starting point and hopefully can only be made better, this approach
+takes inspiration from the work done by [Holden Karau](https://github.com/holdenk) in the [spark-testing-base](https://github.com/holdenk/spark-testing-base) repository.
+You can check the wiki for that [DataFrameGenerator](https://github.com/holdenk/spark-testing-base/wiki/DataFrameGenerator) and see how the scala solution is done there.
+Here the approach to property based testing is similar.
+
+There are two methods in the dataframe_generator module, `for_all` and `check_property` that you can make use of to do property checks.
+
+For instance, the following simple test:
+
+```python
+def test_that_passes(self):
+    schema: StructType = StructType([
+        StructField("string", StringType(), True),
+        StructField("number1", IntegerType(), True),
+        StructField("number2", IntegerType(), True),
+    ])
+
+    def transformation(df: DataFrame) -> DataFrame:
+        return df.withColumn("number_sum", col("number1") + col("number2")).limit(2)
+
+    df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema, transformer=transformation)
+
+    new_data_schema: StructType = StructType([
+        StructField("string", StringType(), True),
+        StructField("number1", IntegerType(), True),
+        StructField("number2", IntegerType(), True),
+        StructField("number_sum", IntegerType(), True),
+    ])
+
+    property_results: Iterator[PropertyResult] = for_all(
+        dfs=df_gen.arbitrary_dataframes(),
+        property_to_check=lambda df: df.schema == new_data_schema and df.count() == 2
+    )
+    self.assertTrue(check_property(property_results=property_results))
+```
+
+will check the property defined in the `property_to_check` parameter in all the DataFrames and generate a report that is
+then passed to the `check_property` that will either return True if all DataFrames conform to the property or it will raise
+a `PropertyCheckException` and show the failed DataFrames in a pretty table.
+
+Changing the property to check to:
+
+```python
+lambda df: df.schema == new_data_schema and df.count() == 3
+```
+
+Will cause the test to fail, and it will print out the DataFrames that failed the property check:
+
+```shell
+E           chispa.dataframe_generator.PropertyCheckException: Property Check failed:
+E           +----------------------+------------+-------------+------------+
+E           |        string        |  number1   |   number2   | number_sum |
+E           +----------------------+------------+-------------+------------+
+E           | eRNTppUYCUECmgCEDLUu | 1035096828 | -1427731638 | -392634810 |
+E           | rQPPNXQuSGVuidEnWCxS | 774843839  | -1050333669 | -275489830 |
+E           +----------------------+------------+-------------+------------+
+E           +----------------------+-------------+-------------+-------------+
+E           |        string        |   number1   |   number2   |  number_sum |
+E           +----------------------+-------------+-------------+-------------+
+E           | DYldTLJOXDsoLmpaSAUQ | -2040281200 |  -106962224 | -2147243424 |
+E           | AjSnLZSGoGAjPcufpUgc |  709943750  | -1092598909 |  -382655159 |
+E           +----------------------+-------------+-------------+-------------+
+E           +----------------------+------------+------------+-------------+
+E           |        string        |  number1   |  number2   |  number_sum |
+E           +----------------------+------------+------------+-------------+
+E           | BStGdFtsgZEyNSdAkLPr | 1526463691 | 1333610860 | -1434892745 |
+E           | ddIYTJHNDWSXglhaTrnn | 482503049  | 1506843170 |  1989346219 |
+E           +----------------------+------------+------------+-------------+
+.
+.
+.
+```
+
 ## Supported PySpark / Python versions
 
 chispa currently supports PySpark 2.4+ and Python 3.5+.
@@ -448,6 +752,7 @@ These dependencies are vendored:
 
 * [six](https://github.com/benjaminp/six)
 * [PrettyTable](https://github.com/jazzband/prettytable)
+* [Faker](https://github.com/joke2k/faker)
 
 The dependencies are vendored to save you from dependency hell.
 

--- a/chispa/dataframe_generator.py
+++ b/chispa/dataframe_generator.py
@@ -1,17 +1,53 @@
 import copy
-import uuid
 from dataclasses import dataclass, field
-from functools import reduce
-from typing import List, Dict, Iterator, Any
+from typing import List, Iterator, Any, Optional, Hashable
 
-import cloudpickle
-import pyspark.serializers
 from faker import Factory, Generator
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import udf
 from pyspark.sql.types import StructType, StructField
 
-pyspark.serializers.cloudpickle = cloudpickle
+# TODO add missing Spark types.
+DEFAULT_CONFIG: dict = {
+    "StringType": {"provider": "pystr"},
+    "ByteType": {"provider": "pyint", "kwargs": {"min_value": -128, "max_value": 127}},
+    "ShortType": {"provider": "pyint", "kwargs": {"min_value": -32768, "max_value": 32767}},
+    "IntegerType": {"provider": "pyint", "kwargs": {"min_value": -2147483648, "max_value": 2147483647}},
+    "LongType": {"provider": "pyint", "kwargs": {"min_value": -9223372036854775808, "max_value": 9223372036854775807}},
+    "DoubleType": {"provider": "pyfloat"},
+    "FloatType": {"provider": "pyfloat"},
+    "DecimalType(10,0)": {"provider": "pydecimal", "kwargs": {"left_digits": 10, "right_digits": 0}},
+    "DateType": {"provider": "date_object"},
+    "TimestampType": {"provider": "date_time"},
+    "BooleanType": {"provider": "pybool"},
+    "BinaryType": {"provider": "binary", "kwargs": {"length": 64}}
+}
+
+
+class DataTypeMissingException(Exception):
+    """DataType missing from default config"""
+
+    def __init__(self):
+        super().__init__("DataType missing from default config")
+
+
+class PropertyCheckException(Exception):
+    """Property Check failed"""
+
+    def __init__(self, message):
+        super().__init__(f"Property Check failed: {message}")
+
+
+@dataclass
+class Report:
+    property_check: bool
+    dataframe: DataFrame
+
+
+@dataclass
+class DataConfig:
+    data_type: str
+    provider: str
+    kwargs: dict = field(default_factory=dict)
 
 
 def default_field(obj):
@@ -19,28 +55,6 @@ def default_field(obj):
     Method to deal with complex objects when using default values for dataclasses.
     """
     return field(default_factory=lambda: copy.copy(obj))
-
-
-def for_all(dfs: Iterator[DataFrame], property_to_check: Any) -> Iterator[bool]:
-    """
-    Method that will run a property over all the DataFrames in the iterator and returns an iterator
-    with the boolean result.
-
-    :param dfs: A generator with DataFrames.
-    :param property_to_check: A function that has a DataFrame as a parameter and returns a bool.
-    :return:
-    """
-    return map(lambda df: property_to_check(df), dfs)
-
-
-def check_property(reports: Iterator[bool]):
-    """
-    Method that will assert if the property that ran over the DataFrames is true for all of them.
-
-    :param reports:
-    :return:
-    """
-    assert all(list(reports)) is True
 
 
 @dataclass
@@ -60,61 +74,25 @@ class DataFrameGenerator:
         }}
     """
     schema: StructType
+    transformer: Any = None
     num_dataframes: int = 10
+    default_config: dict = default_field(DEFAULT_CONFIG)
     config: dict = field(default_factory=dict)
-    id_column_name = str(uuid.uuid4()).replace("-", "_")
-    num_records: int = 100
+    num_records: int = 10
     faker: Generator = Factory.create()
-    faker_spark_types: Dict[str, str] = default_field({
-        "StringType": "text",
-        "IntegerType": "random_int",
-        "LongType": "random_int",
-        "DateType": "date_object"
-    })
+    seed: Optional[Hashable] = None
 
-    # TODO the data in the DataFrame needs to be randomized more, perhaps check for Faker return types and use that
-    # to randomize the data in the columns a bit more.
-    def arbitrary_dataframe_spark(self) -> Iterator[DataFrame]:
+    def arbitrary_dataframes(self) -> Iterator[DataFrame]:
         """
         Method to generate a number of DataFrames (default is 10).
         :return: An iterator with DataFrames.
         """
-        return map(lambda x: self.generate_in_spark(), range(0, self.num_dataframes))
+        return map(
+            lambda x: self.transformer(self.generate_data()) if self.transformer is not None else self.generate_data(),
+            range(0, self.num_dataframes)
+        )
 
-    def generate_initial_dataframe(self) -> DataFrame:
-        """
-        Method to generate the initial DataFrame consisting of one column with a certain number of records.
-        """
-        data = [(elem,) for elem in range(0, self.num_records)]
-        spark: SparkSession = SparkSession.builder.getOrCreate()
-        return spark.createDataFrame(data, [self.id_column_name])
-
-    def generate_in_spark(self) -> DataFrame:
-        """
-        Method that will take the Spark DataFrame schema provided to the dataclass,
-        iterate over it's fields and call the generate_fake_data method.
-        """
-        return reduce(
-            lambda dataframe, schema_field:
-            self.generate_fake_data(dataframe=dataframe, schema_field=schema_field), self.schema,
-            self.generate_initial_dataframe()
-        ).drop(self.id_column_name)
-
-    def generate_fake_data(self, dataframe: DataFrame, schema_field: StructField) -> DataFrame:
-        """
-        Method that will generate fake data for a specific field and add it to the DataFrame provided using UDFs.
-        A config can be pass with a specific provider for a certain column.
-
-        :param dataframe: The DataFrame to add data to.
-        :param schema_field: The field from the schema to add to the DataFrame.
-        :return: The DataFrame with the column added.
-        """
-        data_type, provider = self.get_datatype_and_provider(schema_field)
-        function = getattr(self.faker, provider)
-        fake_factory_udf = udf(function, data_type)
-        return dataframe.withColumn(schema_field.name, fake_factory_udf())
-
-    def get_datatype_and_provider(self, schema_field: StructField):
+    def get_datatype_and_provider(self, schema_field: StructField) -> DataConfig:
         """
         Helper function to get the needed datatype and Faker provider for a specific field.
 
@@ -122,24 +100,74 @@ class DataFrameGenerator:
         :return: The data type of the field and Faker provider.
         """
         if schema_field.name in self.config:
-            data_type = self.config[schema_field.name].get("data_type")
+            data_type = str(self.config[schema_field.name].get("data_type"))
             provider = self.config[schema_field.name].get("provider")
+            kwargs = self.config[schema_field.name].get("kwargs")
         else:
-            data_type = schema_field.dataType
-            provider = self.faker_spark_types.get(str(schema_field.dataType))
-        return data_type, provider
+            data_type = str(schema_field.dataType)
+            config: dict = self.default_config.get(data_type)
+            if config is not None:
+                provider = config.get("provider")
+            else:
+                raise DataTypeMissingException
+            kwargs: dict = config.get("kwargs", {})
+        return DataConfig(data_type=data_type, provider=provider, kwargs=kwargs)
 
-    def generate_locally(self) -> DataFrame:
+    def use_providers(self, data_config: DataConfig):
+        """
+        Method to make use of the Faker providers to generate the data.
+
+        :param data_config: DataConfig object.
+        :return: Values from the Faker providers.
+        """
+        if self.seed is not None:
+            self.faker.seed(seed=self.seed)
+        return getattr(self.faker, data_config.provider)(**data_config.kwargs) if data_config.kwargs else getattr(
+            self.faker, data_config.provider)()
+
+    def generate_data(self) -> DataFrame:
         """
         Method that will generate fake data for for all fields and then put it into a DataFrame.
         A config can be pass with a specific provider for a certain column. This method does not use UDFs.
+
+        :return: A DataFrame from the data created by Faker.
         """
-        providers: List[str] = [self.get_datatype_and_provider(schema_field)[1] for schema_field in self.schema.fields]
-        data = map(
-            lambda x: list(map(
-                lambda provider:
-                getattr(self.faker, provider)(),
-                providers)),
-            range(1, self.num_records + 1))
+        data_configs: List[DataConfig] = [
+            self.get_datatype_and_provider(schema_field=schema_field) for schema_field in
+            self.schema.fields
+        ]
+        data: Iterator = map(lambda x: list(map(self.use_providers, data_configs)), range(0, self.num_records))
         spark: SparkSession = SparkSession.builder.getOrCreate()
-        return spark.createDataFrame(data, self.schema.names)
+        return spark.createDataFrame(data=data, schema=self.schema)
+
+
+def for_all(dfs: Iterator[DataFrame], property_to_check: Any) -> Iterator[Report]:
+    """
+    Method that will run a property over all the DataFrames in the iterator and returns an iterator
+    with the boolean result.
+
+    :param dfs: A generator with DataFrames.
+    :param property_to_check: A function that has a DataFrame as a parameter and returns a bool.
+    :return: An iterator of Report objects.
+    """
+    return map(lambda df: Report(property_check=property_to_check(df), dataframe=df), dfs)
+
+
+def check_property(reports: Iterator[Report], function_to_run_in_failure: Optional[Any] = None) -> bool:
+    """
+    Method that will assert if the property that ran over the DataFrames is true for all of them.
+
+    :param reports: The reports that contains the property result with the corresponding DataFrame.
+    :param function_to_run_in_failure: Optional function to run over the failed DataFrames.
+    :return: True if the property checked is true for all DataFrames, raises PropertyCheckException with the list
+    of failed DataFrames.
+    """
+    l: List[Report] = list(reports)
+    failed: List[DataFrame] = [elem.dataframe for elem in l if elem.property_check is False]
+    if failed:
+        if function_to_run_in_failure is not None:
+            for df in failed:
+                function_to_run_in_failure(df)
+        raise PropertyCheckException(f"\n{[elem.collect() for elem in failed]}")
+    else:
+        return True

--- a/chispa/dataframe_generator.py
+++ b/chispa/dataframe_generator.py
@@ -1,0 +1,145 @@
+import copy
+import uuid
+from dataclasses import dataclass, field
+from functools import reduce
+from typing import List, Dict, Iterator, Any
+
+import cloudpickle
+import pyspark.serializers
+from faker import Factory, Generator
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.functions import udf
+from pyspark.sql.types import StructType, StructField
+
+pyspark.serializers.cloudpickle = cloudpickle
+
+
+def default_field(obj):
+    """
+    Method to deal with complex objects when using default values for dataclasses.
+    """
+    return field(default_factory=lambda: copy.copy(obj))
+
+
+def for_all(dfs: Iterator[DataFrame], property_to_check: Any) -> Iterator[bool]:
+    """
+    Method that will run a property over all the DataFrames in the iterator and returns an iterator
+    with the boolean result.
+
+    :param dfs: A generator with DataFrames.
+    :param property_to_check: A function that has a DataFrame as a parameter and returns a bool.
+    :return:
+    """
+    return map(lambda df: property_to_check(df), dfs)
+
+
+def check_property(reports: Iterator[bool]):
+    """
+    Method that will assert if the property that ran over the DataFrames is true for all of them.
+
+    :param reports:
+    :return:
+    """
+    assert all(list(reports)) is True
+
+
+@dataclass
+class DataFrameGenerator:
+    """
+    Dataclass that has all the methods and variables necessary to generate fake data.
+    schema should be a StructType object:
+     StructType([
+         StructField("id", LongType(), True),
+         StructField("name", StringType(), True)
+     ])
+    And config is a dictionary with the column name as the key and then another dictionary with the type
+    and provider:
+      config = {"bank_account": {
+         "data_type": StringType(),
+         "provider": "iban"
+        }}
+    """
+    schema: StructType
+    num_dataframes: int = 10
+    config: dict = field(default_factory=dict)
+    id_column_name = str(uuid.uuid4()).replace("-", "_")
+    num_records: int = 100
+    faker: Generator = Factory.create()
+    faker_spark_types: Dict[str, str] = default_field({
+        "StringType": "text",
+        "IntegerType": "random_int",
+        "LongType": "random_int",
+        "DateType": "date_object"
+    })
+
+    # TODO the data in the DataFrame needs to be randomized more, perhaps check for Faker return types and use that
+    # to randomize the data in the columns a bit more.
+    def arbitrary_dataframe_spark(self) -> Iterator[DataFrame]:
+        """
+        Method to generate a number of DataFrames (default is 10).
+        :return: An iterator with DataFrames.
+        """
+        return map(lambda x: self.generate_in_spark(), range(0, self.num_dataframes))
+
+    def generate_initial_dataframe(self) -> DataFrame:
+        """
+        Method to generate the initial DataFrame consisting of one column with a certain number of records.
+        """
+        data = [(elem,) for elem in range(0, self.num_records)]
+        spark: SparkSession = SparkSession.builder.getOrCreate()
+        return spark.createDataFrame(data, [self.id_column_name])
+
+    def generate_in_spark(self) -> DataFrame:
+        """
+        Method that will take the Spark DataFrame schema provided to the dataclass,
+        iterate over it's fields and call the generate_fake_data method.
+        """
+        return reduce(
+            lambda dataframe, schema_field:
+            self.generate_fake_data(dataframe=dataframe, schema_field=schema_field), self.schema,
+            self.generate_initial_dataframe()
+        ).drop(self.id_column_name)
+
+    def generate_fake_data(self, dataframe: DataFrame, schema_field: StructField) -> DataFrame:
+        """
+        Method that will generate fake data for a specific field and add it to the DataFrame provided using UDFs.
+        A config can be pass with a specific provider for a certain column.
+
+        :param dataframe: The DataFrame to add data to.
+        :param schema_field: The field from the schema to add to the DataFrame.
+        :return: The DataFrame with the column added.
+        """
+        data_type, provider = self.get_datatype_and_provider(schema_field)
+        function = getattr(self.faker, provider)
+        fake_factory_udf = udf(function, data_type)
+        return dataframe.withColumn(schema_field.name, fake_factory_udf())
+
+    def get_datatype_and_provider(self, schema_field: StructField):
+        """
+        Helper function to get the needed datatype and Faker provider for a specific field.
+
+        :param schema_field: The field from the schema.
+        :return: The data type of the field and Faker provider.
+        """
+        if schema_field.name in self.config:
+            data_type = self.config[schema_field.name].get("data_type")
+            provider = self.config[schema_field.name].get("provider")
+        else:
+            data_type = schema_field.dataType
+            provider = self.faker_spark_types.get(str(schema_field.dataType))
+        return data_type, provider
+
+    def generate_locally(self) -> DataFrame:
+        """
+        Method that will generate fake data for for all fields and then put it into a DataFrame.
+        A config can be pass with a specific provider for a certain column. This method does not use UDFs.
+        """
+        providers: List[str] = [self.get_datatype_and_provider(schema_field)[1] for schema_field in self.schema.fields]
+        data = map(
+            lambda x: list(map(
+                lambda provider:
+                getattr(self.faker, provider)(),
+                providers)),
+            range(1, self.num_records + 1))
+        spark: SparkSession = SparkSession.builder.getOrCreate()
+        return spark.createDataFrame(data, self.schema.names)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,18 +1,10 @@
 [[package]]
-name = "cloudpickle"
-version = "2.0.0"
-description = "Extended pickling support for Python objects"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.3.9"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "*"
 
 [[package]]
 name = "faker"
@@ -36,11 +28,11 @@ python-versions = "*"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.4.34"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "*"
 
 [[package]]
 name = "py4j"
@@ -52,11 +44,11 @@ python-versions = "*"
 
 [[package]]
 name = "pyspark"
-version = "3.1.2"
+version = "3.0.2"
 description = "Apache Spark Python API"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = "*"
 
 [package.dependencies]
 py4j = "0.10.9"
@@ -64,7 +56,7 @@ py4j = "0.10.9"
 [package.extras]
 ml = ["numpy (>=1.7)"]
 mllib = ["numpy (>=1.7)"]
-sql = ["pandas (>=0.23.2)", "pyarrow (>=1.0.0)"]
+sql = ["pandas (>=0.23.2)", "pyarrow (>=0.15.1)"]
 
 [[package]]
 name = "pytest"
@@ -119,16 +111,12 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "ff7f4e1657eda6e55f16cbcde32fc0f455e720bf7fe6f04062eec1e3dde49fec"
+content-hash = "ab19a69f8dbf37c08501a5e7496def3b2cfce7b6aefebf03507314f8ab46ea6e"
 
 [metadata.files]
-cloudpickle = [
-    {file = "cloudpickle-2.0.0-py3-none-any.whl", hash = "sha256:6b2df9741d06f43839a3275c4e6632f7df6487a1f181f5f46a052d3c917c3d11"},
-    {file = "cloudpickle-2.0.0.tar.gz", hash = "sha256:5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4"},
-]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.3.9-py2.py3-none-any.whl", hash = "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda"},
+    {file = "colorama-0.3.9.tar.gz", hash = "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"},
 ]
 faker = [
     {file = "Faker-8.14.0-py3-none-any.whl", hash = "sha256:7b116034973a9a977a34a8a380354028150edf69f6cfbe55c03a852dd0a4116b"},
@@ -139,15 +127,15 @@ findspark = [
     {file = "findspark-1.4.2.tar.gz", hash = "sha256:6d52971f4417e976aea21aea0f4ac7e470fa365d6139100e03fb76b76eb97da0"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.4.34-py2.py3-none-any.whl", hash = "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a"},
+    {file = "py-1.4.34.tar.gz", hash = "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"},
 ]
 py4j = [
     {file = "py4j-0.10.9-py2.py3-none-any.whl", hash = "sha256:859ba728a7bb43e9c2bf058832759fb97a598bb28cc12f34f5fc4abdec08ede6"},
     {file = "py4j-0.10.9.tar.gz", hash = "sha256:36ec57f43ff8ced260a18aa9a4e46c3500a730cac8860e259cbaa546c2b9db2f"},
 ]
 pyspark = [
-    {file = "pyspark-3.1.2.tar.gz", hash = "sha256:5e25ebb18756e9715f4d26848cc7e558035025da74b4fc325a0ebc05ff538e65"},
+    {file = "pyspark-3.0.2.tar.gz", hash = "sha256:d4f2ced43394ad773f7b516a4bbcb5821a940462a17b1a25f175c83771b62ebc"},
 ]
 pytest = [
     {file = "pytest-3.2.2-py2.py3-none-any.whl", hash = "sha256:b84f554f8ddc23add65c411bf112b2d88e2489fd45f753b1cae5936358bdf314"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,26 +1,46 @@
 [[package]]
+name = "cloudpickle"
+version = "2.0.0"
+description = "Extended pickling support for Python objects"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "colorama"
-version = "0.3.9"
+version = "0.4.4"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "faker"
+version = "8.14.0"
+description = "Faker is a Python package that generates fake data for you."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+text-unidecode = "1.3"
 
 [[package]]
 name = "findspark"
 version = "1.4.2"
 description = "Find pyspark to make it importable."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
 [[package]]
 name = "py"
-version = "1.4.34"
+version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "py4j"
@@ -32,11 +52,11 @@ python-versions = "*"
 
 [[package]]
 name = "pyspark"
-version = "3.0.2"
+version = "3.1.2"
 description = "Apache Spark Python API"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 py4j = "0.10.9"
@@ -44,7 +64,7 @@ py4j = "0.10.9"
 [package.extras]
 ml = ["numpy (>=1.7)"]
 mllib = ["numpy (>=1.7)"]
-sql = ["pandas (>=0.23.2)", "pyarrow (>=0.15.1)"]
+sql = ["pandas (>=0.23.2)", "pyarrow (>=1.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -69,30 +89,65 @@ python-versions = "*"
 [package.dependencies]
 pytest = ">=2.6.0"
 
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "main"
+optional = false
+python-versions = "*"
+
 [metadata]
 lock-version = "1.1"
-python-versions = ">2.7"
-content-hash = "e888a725f6eb21703e2161d14026ba97594ec29b67a07583d05e94a137c97456"
+python-versions = ">=3.7"
+content-hash = "ff7f4e1657eda6e55f16cbcde32fc0f455e720bf7fe6f04062eec1e3dde49fec"
 
 [metadata.files]
+cloudpickle = [
+    {file = "cloudpickle-2.0.0-py3-none-any.whl", hash = "sha256:6b2df9741d06f43839a3275c4e6632f7df6487a1f181f5f46a052d3c917c3d11"},
+    {file = "cloudpickle-2.0.0.tar.gz", hash = "sha256:5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4"},
+]
 colorama = [
-    {file = "colorama-0.3.9-py2.py3-none-any.whl", hash = "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda"},
-    {file = "colorama-0.3.9.tar.gz", hash = "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+faker = [
+    {file = "Faker-8.14.0-py3-none-any.whl", hash = "sha256:7b116034973a9a977a34a8a380354028150edf69f6cfbe55c03a852dd0a4116b"},
+    {file = "Faker-8.14.0.tar.gz", hash = "sha256:2649789e3e0c354dde1b8257d2ba7ed663fc3201e41277581de65c17e8aab10a"},
 ]
 findspark = [
     {file = "findspark-1.4.2-py2.py3-none-any.whl", hash = "sha256:4eeb6d831b28cb869da8f4f1a24eb7ff1b51f11c17e44a713fedc9556ab2ccfe"},
     {file = "findspark-1.4.2.tar.gz", hash = "sha256:6d52971f4417e976aea21aea0f4ac7e470fa365d6139100e03fb76b76eb97da0"},
 ]
 py = [
-    {file = "py-1.4.34-py2.py3-none-any.whl", hash = "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a"},
-    {file = "py-1.4.34.tar.gz", hash = "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 py4j = [
     {file = "py4j-0.10.9-py2.py3-none-any.whl", hash = "sha256:859ba728a7bb43e9c2bf058832759fb97a598bb28cc12f34f5fc4abdec08ede6"},
     {file = "py4j-0.10.9.tar.gz", hash = "sha256:36ec57f43ff8ced260a18aa9a4e46c3500a730cac8860e259cbaa546c2b9db2f"},
 ]
 pyspark = [
-    {file = "pyspark-3.0.2.tar.gz", hash = "sha256:d4f2ced43394ad773f7b516a4bbcb5821a940462a17b1a25f175c83771b62ebc"},
+    {file = "pyspark-3.1.2.tar.gz", hash = "sha256:5e25ebb18756e9715f4d26848cc7e558035025da74b4fc325a0ebc05ff538e65"},
 ]
 pytest = [
     {file = "pytest-3.2.2-py2.py3-none-any.whl", hash = "sha256:b84f554f8ddc23add65c411bf112b2d88e2489fd45f753b1cae5936358bdf314"},
@@ -102,4 +157,16 @@ pytest-describe = [
     {file = "pytest-describe-1.0.0.tar.gz", hash = "sha256:3e2ea0e77efa09edb98cf90423bf1da21a462ed90bd3120f8f98fe7519a167d5"},
     {file = "pytest_describe-1.0.0-py2-none-any.whl", hash = "sha256:cc3862662faa5a6fb721927aaef46b46cf787e4a8163e5459fc8778e650fabad"},
     {file = "pytest_describe-1.0.0-py3-none-any.whl", hash = "sha256:95fe78639d4d16c4a1e7d62c70f63030b217c08d2ee6dca49559fe6e730c6696"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ authors = ["MrPowers <matthewkevinpowers@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.5"
+python = ">=3.7"
+cloudpickle = "^2.0.0"
+Faker = "^8.14.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "3.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-cloudpickle = "^2.0.0"
 Faker = "^8.14.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "chispa"
-version = "0.8.2"
+version = "0.8.3"
 description = "Pyspark test helper library"
 authors = ["MrPowers <matthewkevinpowers@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-Faker = "^8.14.0"
+Faker = "8.14.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "3.2.2"
@@ -16,5 +16,5 @@ pyspark = ">2.0.0"
 findspark = "1.4.2"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_dataframe_generator.py
+++ b/tests/test_dataframe_generator.py
@@ -1,0 +1,57 @@
+from pyspark.sql import DataFrame
+from pyspark.sql.types import StringType, StructType, StructField, LongType, DateType
+
+from chispa.dataframe_generator import DataFrameGenerator, for_all, check_property
+
+SCHEMA = StructType([
+    StructField("num", LongType(), True),
+    StructField("expected_name", StringType(), True),
+    StructField("date", DateType(), True)
+])
+
+
+def describe_dataframe_generator():
+    def test_generate_in_spark():
+        df_gen = DataFrameGenerator(schema=SCHEMA)
+        df_gen.generate_in_spark().show(truncate=False)
+
+    def test_generate_in_spark_one_million_records():
+        df_gen = DataFrameGenerator(schema=SCHEMA, num_records=1000000)
+        print(df_gen.generate_in_spark().count())
+
+    def test_generate_in_spark_with_config():
+        config = {"bank_account": {
+            "data_type": StringType(),
+            "provider": "iban"
+        }}
+        schema = StructType([
+            StructField("bank_account", StringType(), True)
+        ])
+        df_gen = DataFrameGenerator(schema=schema, config=config)
+        df_gen.generate_in_spark().show(truncate=False)
+
+    def test_generate_locally():
+        df_gen = DataFrameGenerator(schema=SCHEMA)
+        df_gen.generate_locally().show(truncate=False)
+
+    def test_generate_locally_one_million_records():
+        df_gen = DataFrameGenerator(schema=SCHEMA, num_records=1000000)
+        print(df_gen.generate_in_spark().count())
+
+    def test_generate_locally_with_config():
+        config = {"bank_account": {
+            "data_type": StringType(),
+            "provider": "iban"
+        }}
+        schema = StructType([
+            StructField("bank_account", StringType(), True)
+        ])
+        df_gen = DataFrameGenerator(schema=schema, config=config)
+        df_gen.generate_locally().show(truncate=False)
+
+    def test_stuff():
+        df_gen = DataFrameGenerator(schema=SCHEMA, num_dataframes=2)
+        arbitrary_dfs = df_gen.arbitrary_dataframe_spark()
+        x = for_all(arbitrary_dfs, lambda df: df.schema == SCHEMA and df.count() >= 100)
+        check_property(x)
+

--- a/tests/test_dataframe_generator.py
+++ b/tests/test_dataframe_generator.py
@@ -1,57 +1,203 @@
+from dataclasses import replace
+from typing import Iterator, List
+from unittest import TestCase
+
 from pyspark.sql import DataFrame
-from pyspark.sql.types import StringType, StructType, StructField, LongType, DateType
+from pyspark.sql.functions import lit
+from pyspark.sql.types import StringType, StructType, StructField, LongType, DateType, ByteType, ShortType, IntegerType, \
+    DecimalType, FloatType, DoubleType, BooleanType, BinaryType, TimestampType, ArrayType
 
-from chispa.dataframe_generator import DataFrameGenerator, for_all, check_property
-
-SCHEMA = StructType([
-    StructField("num", LongType(), True),
-    StructField("expected_name", StringType(), True),
-    StructField("date", DateType(), True)
-])
+from chispa.dataframe_generator import DataFrameGenerator, for_all, check_property, DataConfig, Report, \
+    PropertyCheckException, DataTypeMissingException
+from .spark import *
 
 
-def describe_dataframe_generator():
-    def test_generate_in_spark():
-        df_gen = DataFrameGenerator(schema=SCHEMA)
-        df_gen.generate_in_spark().show(truncate=False)
+class TestDataFrameGenerator(TestCase):
+    schema: StructType = StructType([
+        StructField("expected_name", StringType(), True),
+        StructField("int", IntegerType(), True),
+        StructField("long", LongType(), True),
+        StructField("byte", ByteType(), True),
+        StructField("short", ShortType(), True),
+        StructField("double", DoubleType(), True),
+        StructField("float", FloatType(), True),
+        StructField("decimal", DecimalType(), True),
+        StructField("bool", BooleanType(), True),
+        StructField("binary", BinaryType(), True),
+        StructField("date", DateType(), True),
+        StructField("timestamp", TimestampType(), True)
+    ])
+    df_gen: DataFrameGenerator = DataFrameGenerator(schema=schema, seed=0)
 
-    def test_generate_in_spark_one_million_records():
-        df_gen = DataFrameGenerator(schema=SCHEMA, num_records=1000000)
-        print(df_gen.generate_in_spark().count())
+    test_data = ([1, "dick smith"], [2, "jane smith"], [3, "nick smith"])
+    test_data_schema: StructType = StructType([
+        StructField('id', StringType(), True),
+        StructField('name', StringType(), True)
+    ])
+    test_df: DataFrame = spark.createDataFrame(data=test_data, schema=test_data_schema)
 
-    def test_generate_in_spark_with_config():
-        config = {"bank_account": {
-            "data_type": StringType(),
-            "provider": "iban"
-        }}
+    def test_for_all_given_no_dataframe_and_invalid_property_should_return_empty_list(self):
+        dfs: Iterator[DataFrame] = iter([])
+
+        actual: List[Report] = list(for_all(
+            dfs=dfs,
+            property_to_check=None)
+        )
+        expected: List[Report] = []
+
+        self.assertEquals(expected, actual)
+
+    def test_for_all_given_single_dataframe_and_valid_property_should_return_correct_report(self):
+        dfs: Iterator[DataFrame] = iter([self.test_df])
+
+        actual: List[Report] = list(for_all(
+            dfs=dfs,
+            property_to_check=lambda df: df.schema == self.test_data_schema and df.count() == 3)
+        )
+        expected: List[Report] = [Report(property_check=True, dataframe=self.test_df)]
+
+        self.assertEquals(expected, actual)
+
+    def test_for_all_given_multiple_dataframes_and_valid_property_should_return_correct_report(self):
+        dfs: Iterator[DataFrame] = iter([self.test_df, self.test_df])
+
+        actual: List[Report] = list(for_all(
+            dfs=dfs,
+            property_to_check=lambda df: df.schema == self.test_data_schema and df.count() == 3)
+        )
+        expected: List[Report] = [
+            Report(property_check=True, dataframe=self.test_df),
+            Report(property_check=True, dataframe=self.test_df)
+        ]
+
+        self.assertEquals(expected, actual)
+
+    def test_check_property_given_no_report_should_return_true(self):
+        reports: Iterator[Report] = iter([])
+
+        actual: bool = check_property(reports=reports)
+
+        self.assertTrue(actual)
+
+    def test_check_property_given_valid_report_should_return_true(self):
+        reports: Iterator[Report] = iter([Report(property_check=True, dataframe=self.test_df)])
+
+        actual: bool = check_property(reports=reports)
+
+        self.assertTrue(actual)
+
+    def test_check_property_given_invalid_report_should_raise_exception(self):
+        reports: Iterator[Report] = iter([Report(property_check=False, dataframe=self.test_df)])
+
+        self.assertRaises(PropertyCheckException, check_property, reports=reports)
+
+    def test_arbitrary_dataframes_should_return_correct_default_values_for_dataframes(self):
+        actual: List[DataFrame] = list(self.df_gen.arbitrary_dataframes())
+        length_check: bool = len(actual) == self.df_gen.num_dataframes
+        number_records_check: bool = all([elem.count() == self.df_gen.num_records for elem in actual])
+        schema_check: bool = all([elem.schema == self.schema for elem in actual])
+
+        self.assertTrue(all([length_check, number_records_check, schema_check]))
+
+    def test_arbitrary_dataframes_with_invalid_transformer_should_raise_exception(self):
+        df_gen_with_config: DataFrameGenerator = replace(
+            self.df_gen,
+            transformer=lambda x: x + 1
+        )
+
+        self.assertRaises(Exception, df_gen_with_config.arbitrary_dataframes())
+
+    def test_arbitrary_dataframes_with_transformer_should_return_correct_default_values_for_dataframes(self):
+        number_of_records: int = 10
+        new_column_name: str = "literal"
+        df_gen_with_config: DataFrameGenerator = replace(
+            self.df_gen,
+            transformer=lambda df: df.withColumn(new_column_name, lit(1)).limit(number_of_records)
+        )
         schema = StructType([
-            StructField("bank_account", StringType(), True)
+            StructField("expected_name", StringType(), True),
+            StructField("int", IntegerType(), True),
+            StructField("long", LongType(), True),
+            StructField("byte", ByteType(), True),
+            StructField("short", ShortType(), True),
+            StructField("double", DoubleType(), True),
+            StructField("float", FloatType(), True),
+            StructField("decimal", DecimalType(10, 0), True),
+            StructField("bool", BooleanType(), True),
+            StructField("binary", BinaryType(), True),
+            StructField("date", DateType(), True),
+            StructField("timestamp", TimestampType(), True),
+            StructField(new_column_name, IntegerType(), False)
         ])
-        df_gen = DataFrameGenerator(schema=schema, config=config)
-        df_gen.generate_in_spark().show(truncate=False)
 
-    def test_generate_locally():
-        df_gen = DataFrameGenerator(schema=SCHEMA)
-        df_gen.generate_locally().show(truncate=False)
+        actual: List[DataFrame] = list(df_gen_with_config.arbitrary_dataframes())
+        number_records_check: bool = all([elem.count() == number_of_records for elem in actual])
+        schema_check: bool = all([elem.schema == schema for elem in actual])
 
-    def test_generate_locally_one_million_records():
-        df_gen = DataFrameGenerator(schema=SCHEMA, num_records=1000000)
-        print(df_gen.generate_in_spark().count())
+        self.assertTrue(all([number_records_check, schema_check]))
 
-    def test_generate_locally_with_config():
-        config = {"bank_account": {
+    def test_get_datatype_and_provider_given_schema_field_with_no_expected_type_should_raise_exception(self):
+        schema_field: StructField = StructField("expected_name", ArrayType(StringType()), True)
+
+        self.assertRaises(DataTypeMissingException, self.df_gen.get_datatype_and_provider, schema_field=schema_field)
+
+    def test_get_datatype_and_provider_given_a_schema_field_should_return_correct_data_config_object(self):
+        schema_field: StructField = StructField("expected_name", StringType(), True)
+
+        actual: DataConfig = self.df_gen.get_datatype_and_provider(schema_field=schema_field)
+        expected: DataConfig = DataConfig(data_type="StringType", provider='pystr', kwargs={})
+
+        self.assertEquals(expected, actual)
+
+    def test_get_datatype_and_provider_given_a_schema_field_and_config_should_return_correct_data_config_object(self):
+        config = {"expected_name": {
             "data_type": StringType(),
-            "provider": "iban"
+            "provider": "random_element",
+            "kwargs": {
+                "elements": ('x', 'y')
+            }
         }}
-        schema = StructType([
-            StructField("bank_account", StringType(), True)
-        ])
-        df_gen = DataFrameGenerator(schema=schema, config=config)
-        df_gen.generate_locally().show(truncate=False)
+        df_gen_with_config: DataFrameGenerator = replace(self.df_gen, config=config)
+        schema_field: StructField = StructField("expected_name", StringType(), True)
 
-    def test_stuff():
-        df_gen = DataFrameGenerator(schema=SCHEMA, num_dataframes=2)
-        arbitrary_dfs = df_gen.arbitrary_dataframe_spark()
-        x = for_all(arbitrary_dfs, lambda df: df.schema == SCHEMA and df.count() >= 100)
-        check_property(x)
+        actual: DataConfig = df_gen_with_config.get_datatype_and_provider(schema_field=schema_field)
+        expected: DataConfig = DataConfig(
+            data_type="StringType",
+            provider='random_element',
+            kwargs={"elements": ('x', 'y')}
+        )
 
+        self.assertEquals(expected, actual)
+
+    def test_use_providers_given_data_config_object_should_return_the_correct_value(self):
+        data_config: DataConfig = DataConfig(data_type="StringType", provider="pystr")
+
+        actual: str = self.df_gen.use_providers(data_config=data_config)
+        expected: str = "RNvnAvOpyEVAoNGnVZQU"
+
+        self.assertEquals(expected, actual)
+
+    def test_use_providers_given_data_config_object_with_provider_and_keyword_arguments_should_return_the_correct_value(
+            self):
+        data_config: DataConfig = DataConfig(
+            data_type="StringType",
+            provider="random_element",
+            kwargs={
+                "elements": ('x', 'y')
+            }
+        )
+
+        actual: str = self.df_gen.use_providers(data_config=data_config)
+        expected: str = "y"
+
+        self.assertEquals(expected, actual)
+
+    def test_generate_data_given_a_known_schema_should_return_correct_dataframe(self):
+        actual: DataFrame = self.df_gen.generate_data()
+        actual_count: int = actual.count()
+        actual_schema: StructType = actual.schema
+
+        expected_count: int = 10
+        expected_schema: StructType = self.schema
+
+        self.assertTrue(actual_count == expected_count and actual_schema == expected_schema)


### PR DESCRIPTION
Firstly I just want to say how good this library is, where I work this is what we have been using for a few years to test our PySpark code.

This feature adds to this library the possibility to give the user a bit more versatility while testing by making it possible to generate DataFrames according to a schema and then run certain properties over these DataFrames to make sure your functions are indeed behaving like you expect them to.

This is very much based on the wonderful spark-testing-base Scala library from Holden Karau (https://github.com/holdenk/spark-testing-base) more specifically the DataFrameGenerator class (https://github.com/holdenk/spark-testing-base/wiki/DataFrameGenerator).

However, I think of it as a first step, it’s not perfect, but it can be a good starting point.

The major change is the minimum Python version bump to 3.7, to be able to use dataclasses (https://docs.python.org/3.7/library/dataclasses.html) and also Faker (https://github.com/joke2k/faker) which depends on Python 3.6. The minimum Python version defined, 3.5, is already 7 years old so perhaps a bump is not that bad of an idea. Regarding Faker, it is used to populate the DataFrames with fake data, there are defaults for many Spark data types but this gives the user the ability to make the data for their DataFrames as custom as they want to.

Any feedback is appreciated. Thank you.