### PR TITLE
Provide the options in df_equality into approx_df_equality as well

### DIFF
--- a/chispa/number_helpers.py
+++ b/chispa/number_helpers.py
@@ -10,3 +10,7 @@ def isnan(x):
 
 def nan_safe_equality(x, y) -> bool:
     return (x == y) or (isnan(x) and isnan(y))
+
+
+def nan_safe_approx_equality(x, y, precision) -> bool:
+    return (abs(x-y)<=precision) or (isnan(x) and isnan(y))

--- a/chispa/row_comparer.py
+++ b/chispa/row_comparer.py
@@ -33,10 +33,6 @@ def are_rows_approx_equal(r1: Row, r2: Row, precision: float, allow_nan_equality
     allEqual = True
     for key in d1.keys() & d2.keys():
         if isinstance(d1[key], float) and isinstance(d2[key], float):
-            # print("nan check {} {} if test {}".format(d1[key], d2[key], allow_nan_equality
-            #                                          and not(nan_safe_approx_equality(d1[key], d2[key], precision))))
-            # print("allow_nan_equality {} nan_data_test {}".format(allow_nan_equality, not(nan_safe_approx_equality(d1[key], d2[key], precision))))
-            # print("float_diff {}".format(abs(d1[key] - d2[key]) ))
             if allow_nan_equality and not(nan_safe_approx_equality(d1[key], d2[key], precision)):
                 allEqual = False
             elif not(allow_nan_equality) and math.isnan(abs(d1[key] - d2[key])):


### PR DESCRIPTION
W.ref.to https://github.com/MrPowers/chispa/issues/22 
Added the following options to `assert_approx_df_equality` function.
`1. allow_nan_equality
2. ignore_column_order
3. ignore_row_order
4. ignore_schema`

The option `ignore_nullable` is already present. 

This is done  by making use of the existing `assert_df_equality` function. 

Also added 3 tests on approx dataframe comparision to test the new options added.

All tests are passing. 
![image](https://user-images.githubusercontent.com/30562546/197553973-338869d1-79c1-4687-b134-c43d1219f03d.png)

