### PR TITLE
docs(README): update poetry installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fun fact: "chispa" means Spark in Spanish ;)
 
 Install the latest version with `pip install chispa`.
 
-If you use Poetry, add this library as a development dependency with `poetry add chispa --dev`.
+If you use Poetry, add this library as a development dependency with `poetry add chispa -G dev`.
 
 ## Column equality
 


### PR DESCRIPTION
The `--dev` flag is deprecated. 
Poetry warns to use `-G dev` or `--group dev` to add dependencies to the `dev` dependency group.