### PR TITLE
Add rows comparer

### DIFF
--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -27,3 +27,4 @@ except ImportError:
 
 from .dataframe_comparer import DataFramesNotEqualError, assert_df_equality, assert_approx_df_equality
 from .column_comparer import ColumnsNotEqualError, assert_column_equality, assert_approx_column_equality
+from .rows_comparer import assert_basic_rows_equality

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -1,9 +1,6 @@
-from chispa.prettytable import PrettyTable
-from chispa.bcolors import *
 from chispa.schema_comparer import assert_schema_equality
 from chispa.row_comparer import *
 from chispa.rows_comparer import assert_basic_rows_equality, assert_generic_rows_equality
-import chispa.six as six
 from functools import reduce
 
 
@@ -13,7 +10,7 @@ class DataFramesNotEqualError(Exception):
 
 
 def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False,
-                       ignore_column_order=False, ignore_row_order=False, ignore_schema=False):
+                       ignore_column_order=False, ignore_row_order=False):
     if transforms is None:
         transforms = []
     if ignore_column_order:
@@ -22,8 +19,7 @@ def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_n
         transforms.append(lambda df: df.sort(df.columns))
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
-    if not ignore_schema:
-        assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
+    assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if allow_nan_equality:
         assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
     else:
@@ -39,7 +35,7 @@ def are_dfs_equal(df1, df2):
 
 
 def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transforms=None, allow_nan_equality=False,
-                       ignore_column_order=False, ignore_row_order=False, ignore_schema=False):
+                       ignore_column_order=False, ignore_row_order=False):
     if transforms is None:
         transforms = []
     if ignore_column_order:
@@ -48,8 +44,7 @@ def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transf
         transforms.append(lambda df: df.sort(df.columns))
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
-    if not ignore_schema:
-        assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
+    assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if precision != 0:
         assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_approx_equal, [precision, allow_nan_equality])
     elif allow_nan_equality:

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -2,6 +2,7 @@ from chispa.prettytable import PrettyTable
 from chispa.bcolors import *
 from chispa.schema_comparer import assert_schema_equality
 from chispa.row_comparer import *
+from chispa.rows_comparer import assert_basic_rows_equality, assert_generic_rows_equality
 import chispa.six as six
 from functools import reduce
 
@@ -24,9 +25,9 @@ def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_n
     if not ignore_schema:
         assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if allow_nan_equality:
-        assert_generic_rows_equality(df1, df2, are_rows_equal_enhanced, [True])
+        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
     else:
-        assert_basic_rows_equality(df1, df2)
+        assert_basic_rows_equality(df1.collect(), df2.collect())
 
 
 def are_dfs_equal(df1, df2):
@@ -50,47 +51,10 @@ def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transf
     if not ignore_schema:
         assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if precision != 0:
-        assert_generic_rows_equality(df1, df2, are_rows_approx_equal, [precision, allow_nan_equality])
+        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_approx_equal, [precision, allow_nan_equality])
     elif allow_nan_equality:
-        assert_generic_rows_equality(df1, df2, are_rows_equal_enhanced, [True])
+        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
     else:
-        assert_basic_rows_equality(df1, df2)
+        assert_basic_rows_equality(df1.collect(), df2.collect())
 
 
-def assert_generic_rows_equality(df1, df2, row_equality_fun, row_equality_fun_args):
-    df1_rows = df1.collect()
-    df2_rows = df2.collect()
-    zipped = list(six.moves.zip_longest(df1_rows, df2_rows))
-    t = PrettyTable(["df1", "df2"])
-    allRowsEqual = True
-    for r1, r2 in zipped:
-        # rows are not equal when one is None and the other isn't
-        if (r1 is not None and r2 is None) or (r2 is not None and r1 is None):
-            allRowsEqual = False
-            t.add_row([r1, r2])
-        # rows are equal
-        elif row_equality_fun(r1, r2, *row_equality_fun_args):
-            first = bcolors.LightBlue + str(r1) + bcolors.LightRed
-            second = bcolors.LightBlue + str(r2) + bcolors.LightRed
-            t.add_row([first, second])
-        # otherwise, rows aren't equal
-        else:
-            allRowsEqual = False
-            t.add_row([r1, r2])
-    if allRowsEqual == False:
-        raise DataFramesNotEqualError("\n" + t.get_string())
-
-
-
-def assert_basic_rows_equality(df1, df2):
-    rows1 = df1.collect()
-    rows2 = df2.collect()
-    if rows1 != rows2:
-        t = PrettyTable(["df1", "df2"])
-        zipped = list(six.moves.zip_longest(rows1, rows2))
-        for r1, r2 in zipped:
-            if r1 == r2:
-                t.add_row([blue(r1), blue(r2)])
-            else:
-                t.add_row([r1, r2])
-        raise DataFramesNotEqualError("\n" + t.get_string())

--- a/chispa/rows_comparer.py
+++ b/chispa/rows_comparer.py
@@ -1,0 +1,40 @@
+import chispa.six as six
+from chispa.prettytable import PrettyTable
+from chispa.bcolors import *
+import chispa
+
+def assert_basic_rows_equality(rows1, rows2):
+    if rows1 != rows2:
+        t = PrettyTable(["df1", "df2"])
+        zipped = list(six.moves.zip_longest(rows1, rows2))
+        for r1, r2 in zipped:
+            if r1 == r2:
+                t.add_row([blue(r1), blue(r2)])
+            else:
+                t.add_row([r1, r2])
+        raise chispa.DataFramesNotEqualError("\n" + t.get_string())
+
+
+def assert_generic_rows_equality(rows1, rows2, row_equality_fun, row_equality_fun_args):
+    df1_rows = rows1
+    df2_rows = rows2
+    zipped = list(six.moves.zip_longest(df1_rows, df2_rows))
+    t = PrettyTable(["df1", "df2"])
+    allRowsEqual = True
+    for r1, r2 in zipped:
+        # rows are not equal when one is None and the other isn't
+        if (r1 is not None and r2 is None) or (r2 is not None and r1 is None):
+            allRowsEqual = False
+            t.add_row([r1, r2])
+        # rows are equal
+        elif row_equality_fun(r1, r2, *row_equality_fun_args):
+            first = bcolors.LightBlue + str(r1) + bcolors.LightRed
+            second = bcolors.LightBlue + str(r2) + bcolors.LightRed
+            t.add_row([first, second])
+        # otherwise, rows aren't equal
+        else:
+            allRowsEqual = False
+            t.add_row([r1, r2])
+    if allRowsEqual == False:
+        raise chispa.DataFramesNotEqualError("\n" + t.get_string())
+

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -17,24 +17,6 @@ def describe_assert_df_equality():
             assert_df_equality(df1, df2)
 
 
-    def it_can_compare_ignoring_schema():
-        data1 = [(1.0, "jose"), (2.0, "li"), (3.0, "laura")]
-        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
-        print(df1.schema)
-        data2 = [(1, "jose"), (2, "li"), (3, "laura")]
-        df2 = spark.createDataFrame(data2, ["num", "expected_name"])
-        print(df2.schema)
-        assert_df_equality(df1, df2, ignore_schema=True)
-
-
-    def it_raises_when_ignoring_schema_for_mismatched_dfs():
-        data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
-        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
-        data2 = [("li", 1.05), ("laura", 1.2), (None, None), ("jose", 1.0)]
-        df2 = spark.createDataFrame(data2, ["another_name", "same_num"])
-        with pytest.raises(DataFramesNotEqualError):
-            assert_df_equality(df1, df2, 0.1, ignore_schema=True)
-
 
     def it_can_work_with_different_row_orders():
         data1 = [(1, "jose"), (2, "li")]
@@ -176,14 +158,6 @@ def describe_assert_approx_df_equality():
             assert_approx_df_equality(df1, df2, 0.1)
 
 
-    def it_throws_with_with_mismatch_when_schema_is_ignored():
-        data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
-        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
-        data2 = [("li", 1.05), ("laura", 1.2), (None, None), ("jose", 1.0)]
-        df2 = spark.createDataFrame(data2, ["another_name", "same_num"])
-        with pytest.raises(DataFramesNotEqualError) as e_info:
-            assert_approx_df_equality(df1, df2, 0.1, ignore_schema=True)
-
 
     def it_does_not_throw_with_no_mismatch():
         data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
@@ -199,14 +173,6 @@ def describe_assert_approx_df_equality():
         data2 = [("li", 1.05), ("laura", 1.2), (None, None), ("jose", 1.0)]
         df2 = spark.createDataFrame(data2, ["expected_name", "num"])
         assert_approx_df_equality(df1, df2, 0.1, ignore_row_order=True, ignore_column_order=True)
-
-
-    def it_does_not_throw_with_different_schema():
-        data1 = [(1.0, "jose"), (1.1, "li"), (1.2, "laura"), (None, None)]
-        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
-        data2 = [("li", 1.05), ("laura", 1.2), (None, None), ("jose", 1.0)]
-        df2 = spark.createDataFrame(data2, ["another_name", "same_num"])
-        assert_approx_df_equality(df1, df2, 0.1, ignore_schema=True)
 
 
     def it_does_not_throw_with_nan_values():

--- a/tests/test_rows_comparer.py
+++ b/tests/test_rows_comparer.py
@@ -1,0 +1,25 @@
+import pytest
+
+from .spark import *
+from chispa import *
+from chispa.rows_comparer import assert_basic_rows_equality
+from chispa import DataFramesNotEqualError
+import math
+
+
+def describe_assert_basic_rows_equality():
+    def it_throws_with_row_mismatches():
+        data1 = [(1, "jose"), (2, "li"), (3, "laura")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [("bob", "jose"), ("li", "li"), ("luisa", "laura")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError) as e_info:
+            assert_basic_rows_equality(df1.collect(), df2.collect())
+
+    def it_works_when_rows_are_the_same():
+        data1 = [(1, "jose"), (2, "li"), (3, "laura")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [(1, "jose"), (2, "li"), (3, "laura")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        assert_basic_rows_equality(df1.collect(), df2.collect())
+


### PR DESCRIPTION
This PR introduced a bug: https://github.com/MrPowers/chispa/pull/32

We've been chatting about the bug in this issue: https://github.com/MrPowers/chispa/issues/54

Here's the current buggy API for comparing DataFrame equality without considering the schema: `assert_df_equality(df1, df2, ignore_schema=True)`

Here's the proposed new API: `assert_basic_rows_equality(df1.collect(), df2.collect())`

Let me know what you think.