### PR TITLE
pkg_resources removed to stop deprecation warnings in output using pr…

### DIFF
--- a/chispa/prettytable.py
+++ b/chispa/prettytable.py
@@ -41,9 +41,6 @@ import sys
 import textwrap
 import unicodedata
 
-import pkg_resources
-
-# __version__ = pkg_resources.get_distribution(__name__).version
 __version__ = "0.7.2"
 py3k = sys.version_info[0] >= 3
 if py3k:


### PR DESCRIPTION
Addresses issue #58 where using any of the assert methods that includes prettytable.py, produces a warning messages that a dependency of prettytable.py is deprecated.

Removes pkg_resources from prettytable.py to remove the deprecation warning.