### PR TITLE
Highlight mismatching values option for assert_df_equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ This library requires you to set a flag to consider two NaN values to be equal.
 assert_df_equality(df1, df2, allow_nan_equality=True)
 ```
 
+### Underline differences within rows
+
+You can choose to underline columns within a row that are different by setting `underline_cells` to True, i.e.:
+
+```python
+assert_df_equality(df1, df2, underline_cells=True)
+```
+
 ## Approximate column equality
 
 We can check if columns are approximately equal, which is especially useful for floating number comparisons.

--- a/chispa/bcolors.py
+++ b/chispa/bcolors.py
@@ -1,30 +1,40 @@
 class bcolors:
-    NC='\033[0m' # No Color, reset all
+    NC = '\033[0m'  # No Color, reset all
 
-    Bold='\033[1m'
-    Underlined='\033[4m'
-    Blink='\033[5m'
-    Inverted='\033[7m'
-    Hidden='\033[8m'
+    Bold = '\033[1m'
+    Underlined = '\033[4m'
+    Blink = '\033[5m'
+    Inverted = '\033[7m'
+    Hidden = '\033[8m'
 
-    Black='\033[30m'
-    Red='\033[31m'
-    Green='\033[32m'
-    Yellow='\033[33m'
-    Blue='\033[34m'
-    Purple='\033[35m'
-    Cyan='\033[36m'
-    LightGray='\033[37m'
-    DarkGray='\033[30m'
-    LightRed='\033[31m'
-    LightGreen='\033[32m'
-    LightYellow='\033[93m'
-    LightBlue='\033[34m'
-    LightPurple='\033[35m'
-    LightCyan='\033[36m'
-    White='\033[97m'
+    Black = '\033[30m'
+    Red = '\033[31m'
+    Green = '\033[32m'
+    Yellow = '\033[33m'
+    Blue = '\033[34m'
+    Purple = '\033[35m'
+    Cyan = '\033[36m'
+    LightGray = '\033[37m'
+    DarkGray = '\033[30m'
+    LightRed = '\033[31m'
+    LightGreen = '\033[32m'
+    LightYellow = '\033[93m'
+    LightBlue = '\033[34m'
+    LightPurple = '\033[35m'
+    LightCyan = '\033[36m'
+    White = '\033[97m'
+
+    # Style
+    Bold = '\033[1m'
+    Underline = '\033[4m'
 
 
 def blue(s: str) -> str:
-  return bcolors.LightBlue + str(s) + bcolors.LightRed
+    return bcolors.LightBlue + str(s) + bcolors.LightRed
 
+
+def underline_text(input_text: str) -> str:
+    """
+    Takes an input string and returns a white, underlined string (based on PrettyTable formatting)
+    """
+    return bcolors.White + bcolors.Underline + input_text + bcolors.NC + bcolors.LightRed

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -10,7 +10,7 @@ class DataFramesNotEqualError(Exception):
 
 
 def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False,
-                       ignore_column_order=False, ignore_row_order=False):
+                       ignore_column_order=False, ignore_row_order=False, underline_cells=False):
     if transforms is None:
         transforms = []
     if ignore_column_order:
@@ -21,9 +21,11 @@ def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_n
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
     assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if allow_nan_equality:
-        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
+        assert_generic_rows_equality(
+            df1.collect(), df2.collect(), are_rows_equal_enhanced, [True], underline_cells=underline_cells)
     else:
-        assert_basic_rows_equality(df1.collect(), df2.collect())
+        assert_basic_rows_equality(
+            df1.collect(), df2.collect(), underline_cells=underline_cells)
 
 
 def are_dfs_equal(df1, df2):
@@ -51,5 +53,3 @@ def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transf
         assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
     else:
         assert_basic_rows_equality(df1.collect(), df2.collect())
-
-

--- a/chispa/rows_comparer.py
+++ b/chispa/rows_comparer.py
@@ -2,8 +2,14 @@ import chispa.six as six
 from chispa.prettytable import PrettyTable
 from chispa.bcolors import *
 import chispa
+from pyspark.sql.types import Row
+from typing import List
 
-def assert_basic_rows_equality(rows1, rows2):
+
+def assert_basic_rows_equality(rows1, rows2, underline_cells=False):
+    if underline_cells:
+        row_column_names = rows1[0].__fields__
+        num_columns = len(row_column_names)
     if rows1 != rows2:
         t = PrettyTable(["df1", "df2"])
         zipped = list(six.moves.zip_longest(rows1, rows2))
@@ -11,16 +17,23 @@ def assert_basic_rows_equality(rows1, rows2):
             if r1 == r2:
                 t.add_row([blue(r1), blue(r2)])
             else:
-                t.add_row([r1, r2])
+                if underline_cells:
+                    t.add_row(__underline_cells_in_row(
+                        r1=r1, r2=r2, row_column_names=row_column_names, num_columns=num_columns))
+                else:
+                    t.add_row([r1, r2])
         raise chispa.DataFramesNotEqualError("\n" + t.get_string())
 
 
-def assert_generic_rows_equality(rows1, rows2, row_equality_fun, row_equality_fun_args):
+def assert_generic_rows_equality(rows1, rows2, row_equality_fun, row_equality_fun_args, underline_cells=False):
     df1_rows = rows1
     df2_rows = rows2
     zipped = list(six.moves.zip_longest(df1_rows, df2_rows))
     t = PrettyTable(["df1", "df2"])
     allRowsEqual = True
+    if underline_cells:
+        row_column_names = rows1[0].__fields__
+        num_columns = len(row_column_names)
     for r1, r2 in zipped:
         # rows are not equal when one is None and the other isn't
         if (r1 is not None and r2 is None) or (r2 is not None and r1 is None):
@@ -34,7 +47,39 @@ def assert_generic_rows_equality(rows1, rows2, row_equality_fun, row_equality_fu
         # otherwise, rows aren't equal
         else:
             allRowsEqual = False
-            t.add_row([r1, r2])
+            # Underline cells if requested
+            if underline_cells:
+                t.add_row(__underline_cells_in_row(
+                    r1=r1, r2=r2, row_column_names=row_column_names, num_columns=num_columns))
+            else:
+                t.add_row([r1, r2])
     if allRowsEqual == False:
         raise chispa.DataFramesNotEqualError("\n" + t.get_string())
 
+
+def __underline_cells_in_row(r1=Row, r2=Row, row_column_names=List[str], num_columns=int) -> List[str]:
+    """
+    Takes two Row types, a list of column names for the Rows and the length of columns
+    Returns list of two strings, with underlined columns within rows that are different for PrettyTable
+    """
+    r1_string = "Row("
+    r2_string = "Row("
+    for index, column in enumerate(row_column_names):
+        if ((index+1) == num_columns):
+            append_str = ""
+        else:
+            append_str = ", "
+
+        if r1[column] != r2[column]:
+            r1_string += underline_text(
+                f"{column}='{r1[column]}'") + f"{append_str}"
+            r2_string += underline_text(
+                f"{column}='{r2[column]}'") + f"{append_str}"
+        else:
+            r1_string += f"{column}='{r1[column]}'{append_str}"
+            r2_string += f"{column}='{r2[column]}'{append_str}"
+
+    r1_string += ")"
+    r2_string += ")"
+
+    return [bcolors.LightRed + r1_string, r2_string]


### PR DESCRIPTION
# Description

Added a Boolean flag for `assert_df_equality` that when enabled, highlights the differences within rows. Example:

![updated_table_with_underlining](https://github.com/MrPowers/chispa/assets/9860977/fb99791f-c60f-4ba8-a11c-e1deef55d784)

Usage: `assert_df_equality(df1, df2, underline_cells=True)`

Fixes #52

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Passes existing testing suite (`poetry run pytest tests`)
- [x] Performance testing

# Impacts to performance

To assess any impact to performance, I ran some quick tests comparing `assert_df_equality` with `underline_cells` disabled and then enabled to compare.

## Setup

- Spark on local
- Sample Dataframe was 10,000 rows
- Used `timeit` package, with 100 executions

## Results

No significant difference noted. Results show % change compared to baseline when `underline_cells` is disabled.

<table>
<thead>
  <tr>
    <th rowspan="2">Number of columns in both df1 and df2</th>
    <th colspan="3">Number of changes from df1 to df2</th>
  </tr>
  <tr>
    <th>20</th>
    <th>150</th>
    <th>300</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>5</td>
    <td>+0.24%</td>
    <td>+0.77%</td>
    <td>+0.76%</td>
  </tr>
  <tr>
    <td>25</td>
    <td>+0.29%</td>
    <td>+0.73%</td>
    <td>+0.72%</td>
  </tr>
</tbody>
</table>


