### PR TITLE
Adding new __repr__ for pyspark StructField such that the error logs explicitly show metadata differences

### DIFF
--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -1,11 +1,25 @@
 from chispa.prettytable import PrettyTable
 from chispa.bcolors import *
 import chispa.six as six
+from pyspark.sql.types import StructField
 
 
 class SchemasNotEqualError(Exception):
    """The schemas are not equal"""
    pass
+
+
+class StructFieldPrettyPrint(StructField):
+    def __init__(self, structfield: StructField) -> None:
+        self.structfield = structfield
+
+    def __repr__(self):
+        return "StructField(%s, %s, %s, %s)" % (
+            self.structfield.name,
+            self.structfield.dataType,
+            str(self.structfield.nullable).lower(),
+            str(self.structfield.metadata)
+        ) 
 
 
 def assert_schema_equality(s1, s2, ignore_nullable=False, ignore_metadata=False):
@@ -30,9 +44,9 @@ def assert_schema_equality_full(s1, s2, ignore_nullable=False, ignore_metadata=F
         zipped = list(six.moves.zip_longest(s1, s2))
         for sf1, sf2 in zipped:
             if are_structfields_equal(sf1, sf2, True):
-                t.add_row([blue(sf1), blue(sf2)])
+                t.add_row([blue(StructFieldPrettyPrint(sf1)), blue(StructFieldPrettyPrint(sf2))])
             else:
-                t.add_row([sf1, sf2])
+                t.add_row([StructFieldPrettyPrint(sf1), StructFieldPrettyPrint(sf2)])
         raise SchemasNotEqualError("\n" + t.get_string())
 
 
@@ -45,9 +59,9 @@ def assert_basic_schema_equality(s1, s2):
         zipped = list(six.moves.zip_longest(s1, s2))
         for sf1, sf2 in zipped:
             if sf1 == sf2:
-                t.add_row([blue(sf1), blue(sf2)])
+                t.add_row([blue(StructFieldPrettyPrint(sf1)), blue(StructFieldPrettyPrint(sf2))])
             else:
-                t.add_row([sf1, sf2])
+                t.add_row([StructFieldPrettyPrint(sf1), StructFieldPrettyPrint(sf2)])
         raise SchemasNotEqualError("\n" + t.get_string())
 
 
@@ -59,9 +73,9 @@ def assert_schema_equality_ignore_nullable(s1, s2):
         zipped = list(six.moves.zip_longest(s1, s2))
         for sf1, sf2 in zipped:
             if are_structfields_equal(sf1, sf2, True):
-                t.add_row([blue(sf1), blue(sf2)])
+                t.add_row([blue(StructFieldPrettyPrint(sf1)), blue(StructFieldPrettyPrint(sf2))])
             else:
-                t.add_row([sf1, sf2])
+                t.add_row([StructFieldPrettyPrint(sf1), StructFieldPrettyPrint(sf2)])
         raise SchemasNotEqualError("\n" + t.get_string())
 
 


### PR DESCRIPTION
# Description
Added a new class `StructFieldPrettyPrint` that will allow better representation of the `StructFIeld` type to show the name, data type, nullability, and the metadata. Currently pyspark's `__repr__` attribute ([docs](https://spark.apache.org/docs/3.1.1/api/python/_modules/pyspark/sql/types.html#StructField)) only returns:

```
return "StructField(%s,%s,%s)" % (self.name, self.dataType,
                                          str(self.nullable).lower())
```

This is not ideal when users want to compare all the attributes including metadata since it won't show up in the error message.

The new `__repr__` in the `StructFieldPrettyPrint` will override the pyspark `StructField`'s `__repr__` method with something more explicit:

```
return "StructField(%s, %s, %s, %s)" % (
            self.structfield.name,
            self.structfield.dataType,
            str(self.structfield.nullable).lower(),
            str(self.structfield.metadata)
        ) 
```

### Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How has this been tested?
- [x] Passes existing testing suite (`pytest tests/`)