### PR TITLE
Add unit tests for multiple python versions to CI stage

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -1,0 +1,54 @@
+name: "setup-poetry-env"
+description: "Composite action to setup the Python and poetry environment."
+
+inputs:
+  python-version:
+    required: false
+    description: "The python version to use"
+    default: "3.11"
+  with-docs:
+    required: false
+    description: "Install the docs dependency group"
+    default: 'false'
+  
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Poetry
+      env:
+        # renovate: datasource=pypi depName=poetry
+        POETRY_VERSION: "1.8.3"
+      run: curl -sSL https://install.python-poetry.org | python - -y
+      shell: bash
+
+    - name: Add Poetry to Path
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      shell: bash
+
+    - name: Configure Poetry virtual environment in project
+      run: poetry config virtualenvs.in-project true
+      shell: bash
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.with-docs }}-${{ hashFiles('poetry.lock') }}
+
+    - name: Install dependencies
+      run: |
+        if [[ "${{ inputs.with-docs }}" == "true" ]]; then
+          poetry install --no-interaction --with mkdocs
+        else
+          poetry install --no-interaction
+        fi
+      shell: bash
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Check lock file
         run: poetry lock --check
 
-      - name: Run pre-commit hooks
-        run: poetry run pre-commit run -a --show-diff-on-failure
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
+
+      - name: Run pre-commit hooks
+        run: poetry run pre-commit run -a --show-diff-on-failure
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,44 @@
 name: Unit tests
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   push:
-    branches:
-    - main
+    branches: [main]
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v1
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
         with:
-          fetch-depth: 1
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - name: Run tests
+        run: poetry run pytest tests
+
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
         with:
-          python-version: 3.9
+          with-docs: true
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+      - name: Check if documentation can be built
+        run: poetry run mkdocs build -s
 
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        run: poetry install
-        if: steps.cache.outputs.cache-hit != 'true'
-
-      - name: Run tests with pytest
-        run: poetry run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env
 
+      - name: Check lock file
+        run: poetry lock --check
+
       - name: Run pre-commit hooks
         run: poetry run pre-commit run -a --show-diff-on-failure
 

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -12,26 +12,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
         with:
-          python-version: 3.9
-      - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: 1.4.0
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        run:
-          poetry install --with mkdocs
-        if: steps.cache.outputs.cache-hit != 'true'
+          with-docs: true
+        
       - name: Setup GH
         run: |
           sudo apt update && sudo apt install -y git

--- a/poetry.lock
+++ b/poetry.lock
@@ -308,17 +308,17 @@ mkdocs = ">=1.1"
 
 [[package]]
 name = "mkdocs-gen-files"
-version = "0.4.0"
+version = "0.5.0"
 description = "MkDocs plugin to programmatically generate documentation pages during the build"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7"
 files = [
-    {file = "mkdocs-gen-files-0.4.0.tar.gz", hash = "sha256:377bff8ee8e93515916689f483d971643f83a94eed7e92318854da8f344f0163"},
-    {file = "mkdocs_gen_files-0.4.0-py3-none-any.whl", hash = "sha256:3241a4c947ecd11763ca77cc645015305bf71a0e1b9b886801c114fcf9971e71"},
+    {file = "mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea"},
+    {file = "mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc"},
 ]
 
 [package.dependencies]
-mkdocs = ">=1.0.3,<2.0.0"
+mkdocs = ">=1.0.3"
 
 [[package]]
 name = "mkdocs-get-deps"
@@ -395,18 +395,18 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "0.8.3"
+version = "1.10.5"
 description = "A Python handler for mkdocstrings."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings-python-0.8.3.tar.gz", hash = "sha256:9ae473f6dc599339b09eee17e4d2b05d6ac0ec29860f3fc9b7512d940fc61adf"},
-    {file = "mkdocstrings_python-0.8.3-py3-none-any.whl", hash = "sha256:4e6e1cd6f37a785de0946ced6eb846eb2f5d891ac1cc2c7b832943d3529087a7"},
+    {file = "mkdocstrings_python-1.10.5-py3-none-any.whl", hash = "sha256:92e3c588ef1b41151f55281d075de7558dd8092e422cb07a65b18ee2b0863ebb"},
+    {file = "mkdocstrings_python-1.10.5.tar.gz", hash = "sha256:acdc2a98cd9d46c7ece508193a16ca03ccabcb67520352b7449f84b57c162bdf"},
 ]
 
 [package.dependencies]
-griffe = ">=0.24"
-mkdocstrings = ">=0.19"
+griffe = ">=0.47"
+mkdocstrings = ">=0.25"
 
 [[package]]
 name = "packaging"
@@ -743,4 +743,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "0e60f2d87e7783c602478426dbbdffb5c96097f55aa8cde361e9403d49704135"
+content-hash = "158d38936b4ec6e4e58fd7cf6c2bb542f7afbb103c683da49dea34ac2ad81554"

--- a/poetry.lock
+++ b/poetry.lock
@@ -743,4 +743,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "158d38936b4ec6e4e58fd7cf6c2bb542f7afbb103c683da49dea34ac2ad81554"
+content-hash = "1a4f9f948aa0969186c97725e6ec6e66be6357874ad36302543eebef8b9ac2d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ findspark = "1.4.2"
 pytest-describe = "^2.1.0"
 
 [tool.poetry.group.mkdocs.dependencies]
-mkdocstrings-python = "^1.7.3"
-mkdocs-gen-files = "^0.5.0"
-mkdocs-literate-nav = "^0.6.0"
-mkdocs-section-index = "^0.3.5"
-markdown-include = "^0.8.1"
-mkdocs = "^1.5.3"
+mkdocs = "^1.6.0"
+mkdocstrings-python = "*"
+mkdocs-gen-files = "*"
+mkdocs-literate-nav = "*"
+mkdocs-section-index = "*"
+markdown-include = "*"
 
 [tool.poetry.group.mkdocs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,22 +8,22 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "7.4.2"
 pyspark = ">3.0.0"
 findspark = "1.4.2"
 pytest-describe = "^2.1.0"
 
-[tool.poetry.group.mkdocs]
-optional = true
-
 [tool.poetry.group.mkdocs.dependencies]
-mkdocstrings-python = "^0.8.3"
-mkdocs-gen-files = "^0.4.0"
+mkdocstrings-python = "^1.7.3"
+mkdocs-gen-files = "^0.5.0"
 mkdocs-literate-nav = "^0.6.0"
 mkdocs-section-index = "^0.3.5"
 markdown-include = "^0.8.1"
-mkdocs = "^1.4.2"
+mkdocs = "^1.5.3"
+
+[tool.poetry.group.mkdocs]
+optional = true
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR builds upon [this PR](https://github.com/MrPowers/chispa/pull/80). When that is merged I can update this branch to better reflect the changes in "Files changed".

Related issue: https://github.com/MrPowers/chispa/issues/82

---

This PR adds testing against multiple Python versions, updates some of the mkdocs dependencies, and changes the trigger of the CI checks to run on each pull request and on each commit to master (i.e. merging a PR). For an example run, see [here](https://github.com/fpgmaas/chispa/actions/runs/6564589223), or approve the workflow run on this PR.

This also adds a check for the `poetry.lock` file; to prevent issues like #107 

I think this can be helpful, let me know what you think of the proposal!