### PR TITLE
add tree_string

### DIFF
--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -16,6 +16,7 @@ def assert_schema_equality(s1, s2, ignore_nullable=False, ignore_metadata=False)
 
 
 def assert_schema_equality_full(s1, s2, ignore_nullable=False, ignore_metadata=False):
+    t = PrettyTable(["schema1", "schema2"])
     def inner(s1, s2, ignore_nullable, ignore_metadata):
         if len(s1) != len(s2):
             return False
@@ -26,7 +27,6 @@ def assert_schema_equality_full(s1, s2, ignore_nullable=False, ignore_metadata=F
         return True
 
     if not inner(s1, s2, ignore_nullable, ignore_metadata):
-        t = PrettyTable(["schema1", "schema2"])
         zipped = list(six.moves.zip_longest(s1, s2))
         for sf1, sf2 in zipped:
             if are_structfields_equal(sf1, sf2, True):
@@ -109,3 +109,32 @@ def are_datatypes_equal_ignore_nullable(dt1, dt2):
             return True
     else:
         return False
+
+
+#   def treeString: String = treeString(Int.MaxValue)
+
+#   def treeString(maxDepth: Int): String = {
+#     val stringConcat = new StringConcat()
+#     stringConcat.append("root\n")
+#     val prefix = " |"
+#     val depth = if (maxDepth > 0) maxDepth else Int.MaxValue
+#     fields.foreach(field => field.buildFormattedString(prefix, stringConcat, depth))
+#     stringConcat.toString()
+#   }
+
+
+def tree_string(structtype, max_depth=10000):
+    string_concat = ""
+    string_concat = string_concat + "root\n"
+    prefix = " |"
+    depth = max_depth if (max_depth > 0) else 5000
+    for field in structtype.fields:
+        if field.dataType.typeName() == "struct":
+            buildFormattedString(field, prefix, string_concat, depth)
+        else:
+            string_concat = string_concat + field.simpleString() + "\n"
+    return string_concat
+    
+def buildFormattedString(fields, prefix, stringConcat, max_depth):    
+    for field in fields:
+        buildFormattedString(field, prefix, stringConcat, max_depth)

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,5 +1,6 @@
 import pytest
 
+from chispa.schema_comparer import assert_schema_equality, tree_string
 from chispa import *
 import pyspark.sql.functions as F
 from chispa.schema_comparer import SchemasNotEqualError
@@ -229,5 +230,63 @@ def describe_schema_mismatch_messages():
             (None, None)
         ]
         df2 = spark.createDataFrame(data2, ["num", "num2"])
+        # assert_df_equality(df1, df2)
         with pytest.raises(SchemasNotEqualError) as e_info:
             assert_df_equality(df1, df2)
+
+
+def describe_schema_comparer():
+    # def test_large_schema_error_messages():
+    #         schema1 = StructType(
+    #             [
+    #                 StructField("id", IntegerType(), True),
+    #                 StructField(
+    #                     "details",
+    #                     StructType(
+    #                         [
+    #                             StructField("name", StringType(), True),
+    #                             StructField("address", StringType(), True),
+    #                             StructField("age", IntegerType(), True),
+    #                         ]
+    #                     ),
+    #                     True,
+    #                 ),
+    #             ]
+    #         )
+    #         schema2 = StructType(
+    #             [
+    #                 StructField("id", IntegerType(), True),
+    #                 StructField(
+    #                     "details",
+    #                     StructType(
+    #                         [
+    #                             StructField("nombre", StringType(), True),
+    #                             StructField("address", StringType(), True),
+    #                             StructField("age", IntegerType(), True),
+    #                         ]
+    #                     ),
+    #                     True,
+    #                 ),
+    #             ]
+    #         )
+    #         assert_schema_equality(schema1, schema2)
+
+
+    def test_tree_string():
+            schema1 = StructType(
+                [
+                    StructField("id", IntegerType(), True),
+                    StructField(
+                        "details",
+                        StructType(
+                            [
+                                StructField("name", StringType(), True),
+                                StructField("address", StringType(), True),
+                                StructField("age", IntegerType(), True),
+                            ]
+                        ),
+                        True,
+                    ),
+                ]
+            )
+            print(tree_string(schema1))


### PR DESCRIPTION
Don't merge this till it's working.

Method that I tried to copy from Spark source code: https://github.com/apache/spark/blob/edf4ac4b518d0d69f7012ff5c0f1428fe45412ba/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala#L399

Purpose: give users a better experience for analyzing diffs between two schemas with nested fields that are hard to read in the terminal.