### PR TITLE
New Chispa interface

### DIFF
--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -28,3 +28,23 @@ except ImportError:
 from .dataframe_comparer import DataFramesNotEqualError, assert_df_equality, assert_approx_df_equality
 from .column_comparer import ColumnsNotEqualError, assert_column_equality, assert_approx_column_equality
 from .rows_comparer import assert_basic_rows_equality
+from chispa.default_formats import DefaultFormats
+
+class Chispa():
+    def __init__(self, formats=DefaultFormats(), default_output=None):
+        self.formats = formats
+        self.default_outputs = default_output
+
+    def assert_df_equality(self, df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False,
+                       ignore_column_order=False, ignore_row_order=False, underline_cells=False, ignore_metadata=False):
+        return assert_df_equality(
+            df1, 
+            df2, 
+            ignore_nullable, 
+            transforms, 
+            allow_nan_equality,
+            ignore_column_order, 
+            ignore_row_order, 
+            underline_cells, 
+            ignore_metadata,
+            self.formats)

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -1,6 +1,7 @@
 from chispa.schema_comparer import assert_schema_equality
-from chispa.row_comparer import *
+from chispa.default_formats import DefaultFormats
 from chispa.rows_comparer import assert_basic_rows_equality, assert_generic_rows_equality
+from chispa.row_comparer import are_rows_equal_enhanced, are_rows_approx_equal
 from functools import reduce
 
 
@@ -10,7 +11,7 @@ class DataFramesNotEqualError(Exception):
 
 
 def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_nan_equality=False,
-                       ignore_column_order=False, ignore_row_order=False, underline_cells=False, ignore_metadata=False):
+                       ignore_column_order=False, ignore_row_order=False, underline_cells=False, ignore_metadata=False, formats=DefaultFormats()):
     if transforms is None:
         transforms = []
     if ignore_column_order:
@@ -22,10 +23,10 @@ def assert_df_equality(df1, df2, ignore_nullable=False, transforms=None, allow_n
     assert_schema_equality(df1.schema, df2.schema, ignore_nullable, ignore_metadata)
     if allow_nan_equality:
         assert_generic_rows_equality(
-            df1.collect(), df2.collect(), are_rows_equal_enhanced, [True], underline_cells=underline_cells)
+            df1.collect(), df2.collect(), are_rows_equal_enhanced, [True], underline_cells=underline_cells, formats=formats)
     else:
         assert_basic_rows_equality(
-            df1.collect(), df2.collect(), underline_cells=underline_cells)
+            df1.collect(), df2.collect(), underline_cells=underline_cells, formats=formats)
 
 
 def are_dfs_equal(df1, df2):
@@ -37,7 +38,7 @@ def are_dfs_equal(df1, df2):
 
 
 def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transforms=None, allow_nan_equality=False,
-                       ignore_column_order=False, ignore_row_order=False):
+                       ignore_column_order=False, ignore_row_order=False, formats=DefaultFormats()):
     if transforms is None:
         transforms = []
     if ignore_column_order:
@@ -48,8 +49,8 @@ def assert_approx_df_equality(df1, df2, precision, ignore_nullable=False, transf
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
     assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
     if precision != 0:
-        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_approx_equal, [precision, allow_nan_equality])
+        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_approx_equal, [precision, allow_nan_equality], formats)
     elif allow_nan_equality:
-        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True])
+        assert_generic_rows_equality(df1.collect(), df2.collect(), are_rows_equal_enhanced, [True], formats)
     else:
-        assert_basic_rows_equality(df1.collect(), df2.collect())
+        assert_basic_rows_equality(df1.collect(), df2.collect(), formats)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from dataclasses import dataclass
+from chispa import Chispa
 
 @dataclass
 class MyFormats:
@@ -11,3 +12,8 @@ class MyFormats:
 @pytest.fixture()
 def my_formats():
     return MyFormats()
+
+
+@pytest.fixture()
+def my_chispa():
+    return Chispa(formats=MyFormats())

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -256,3 +256,27 @@ def describe_schema_mismatch_messages():
         df2 = spark.createDataFrame(data2, ["num", "num2"])
         with pytest.raises(SchemasNotEqualError) as e_info:
             assert_df_equality(df1, df2)
+
+
+def test_remove_non_word_characters_long_error(my_chispa):
+    source_data = [
+        ("matt7",),
+        ("bill&",),
+        ("isabela*",),
+        (None,)
+    ]
+    source_df = spark.createDataFrame(source_data, ["name"])
+    actual_df = source_df.withColumn(
+        "clean_name",
+        remove_non_word_characters(F.col("name"))
+    )
+    expected_data = [
+        ("matt7", "matt"),
+        ("bill&", "bill"),
+        ("isabela*", "isabela"),
+        (None, None)
+    ]
+    expected_df = spark.createDataFrame(expected_data, ["name", "clean_name"])
+    # my_chispa.assert_df_equality(actual_df, expected_df)
+    with pytest.raises(DataFramesNotEqualError) as e_info:
+        assert_df_equality(actual_df, expected_df)


### PR DESCRIPTION
This pull request exposes a `Chispa` class that will make it easier to share instantiate project-level defaults and share them in the test suite.

Here's how users can currently use custom formatting in the configuration file:

```python
@dataclass
class MyFormats:
    mismatched_rows = ["light_yellow"]
    matched_rows = ["cyan", "bold"]
    mismatched_cells = ["purple"]
    matched_cells = ["blue"]


@pytest.fixture()
def my_formats():
    return MyFormats()
```

Here's how the formats can be used

```python
def it_shows_assert_basic_rows_equality(my_formats):
    ...
    assert_basic_rows_equality(df1.collect(), df2.collect(), formats=my_formats)
```

This is a bit tedious because the user needs to pass the formats for every function invocation in the test suite.

The new interface allows for the custom formats to be specified once.  

Here is the `conftest.py` file:

```python
@pytest.fixture()
def my_chispa():
    return Chispa(formats=MyFormats())
```

Here is the test file:

```
def test_remove_non_word_characters_long_error(my_chispa):
    ...
    my_chispa.assert_df_equality(actual_df, expected_df)
```

This PR doesn't add any breaking changes.  All the current interfaces will still work.