### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ docs-test: ## Test if documentation can be built without warnings or errors
 docs: ## Build and serve the documentation
 	@poetry run mkdocs serve
 
+# Inspired by https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help: ## Show help for the commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: install
-install: ## Install the Poetry environment.
+install: ## Install the Poetry environment
 	@echo "Creating virtual environment using Poetry"
 	@poetry install
 
 .PHONY: test
-test: ## Run unit tests.
+test: ## Run unit tests
 	@echo "Running unit tests"
 	@poetry run pytest tests
 
 .PHONY: build
-build: clean-build ## Build wheel and sdist files using Poetry.
+build: clean-build ## Build wheel and sdist files using Poetry
 	@echo "Creating wheel and sdist files"
 	@poetry build
 
@@ -18,7 +18,7 @@ clean-build: ## clean build artifacts
 	@rm -rf dist
 
 .PHONY: publish
-publish: ## Publish a release to PyPI.
+publish: ## Publish a release to PyPI
 	@echo "Publishing: Dry run."
 	@poetry config pypi-token.pypi $(PYPI_TOKEN)
 	@poetry publish --dry-run
@@ -26,18 +26,18 @@ publish: ## Publish a release to PyPI.
 	@poetry publish
 
 .PHONY: build-and-publish
-build-and-publish: build publish ## Build and publish.
+build-and-publish: build publish ## Build and publish
 
 .PHONY: docs-test
-docs-test: ## Test if documentation can be built without warnings or errors.
+docs-test: ## Test if documentation can be built without warnings or errors
 	@poetry run mkdocs build -s
 
 .PHONY: docs
-docs: ## Build and serve the documentation.
+docs: ## Build and serve the documentation
 	@poetry run mkdocs serve
 
 .PHONY: help
-help: ## Show help for the commands.
+help: ## Show help for the commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: install
+install: ## Install the Poetry environment.
+	@echo "Creating virtual environment using Poetry"
+	@poetry install
+
+.PHONY: test
+test: ## Run unit tests.
+	@echo "Running unit tests"
+	@poetry run pytest tests
+
+.PHONY: build
+build: clean-build ## Build wheel and sdist files using Poetry.
+	@echo "Creating wheel and sdist files"
+	@poetry build
+
+.PHONY: clean-build
+clean-build: ## clean build artifacts
+	@rm -rf dist
+
+.PHONY: publish
+publish: ## Publish a release to PyPI.
+	@echo "Publishing: Dry run."
+	@poetry config pypi-token.pypi $(PYPI_TOKEN)
+	@poetry publish --dry-run
+	@echo "Publishing."
+	@poetry publish
+
+.PHONY: build-and-publish
+build-and-publish: build publish ## Build and publish.
+
+.PHONY: docs-test
+docs-test: ## Test if documentation can be built without warnings or errors.
+	@poetry run mkdocs build -s
+
+.PHONY: docs
+docs: ## Build and serve the documentation.
+	@poetry run mkdocs serve
+
+.PHONY: help
+help: ## Show help for the commands.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help


### PR DESCRIPTION
Proposal to add a `Makefile` to the project to make developer's life a bit easier. Running `make help` shows:

```
install              Install the Poetry environment
test                 Run unit tests
build                Build wheel and sdist files using Poetry
clean-build          clean build artifacts
publish              Publish a release to PyPI
build-and-publish    Build and publish
docs-test            Test if documentation can be built without warnings or errors
docs                 Build and serve the documentation
help                 Show help for the commands
```