### PR TITLE
Improve pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/MrPowers/chispa"
 documentation = "https://mrpowers.github.io/chispa"
 readme = "README.md"
 license = "MIT"
-keywords = ["dependency", "poetry"]
+keywords = ['apachespark', 'spark', 'pyspark', 'pytest']
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,30 @@ name = "chispa"
 version = "0.10.0"
 description = "Pyspark test helper library"
 authors = ["MrPowers <matthewkevinpowers@gmail.com>"]
+repository = "https://github.com/MrPowers/chispa"
+documentation = "https://mrpowers.github.io/chispa"
+readme = "README.md"
 license = "MIT"
+keywords = ["dependency", "poetry"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Framework :: Pytest",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,11 @@
 name = "chispa"
 version = "0.10.0"
 description = "Pyspark test helper library"
-authors = ["MrPowers <matthewkevinpowers@gmail.com>"]
+authors = ["Matthew Powers <matthewkevinpowers@gmail.com>"]
+maintainers = [
+    "Semyon Sinchenko <ssinchenko@apache.org>",
+    "Florian Maas <info@fpgmaas.com>"
+]
 repository = "https://github.com/MrPowers/chispa"
 documentation = "https://mrpowers.github.io/chispa"
 readme = "README.md"


### PR DESCRIPTION
This proposes to add some fields to `pyproject.toml`. The main benefit of this will be an improved PyPI page, since currently [that is very empty](https://pypi.org/project/chispa/). 

It also adds @SemyonSinchenko and myself as maintainers and proposes to use full names instead of github handles in the `authors` and `maintainers` fields.

