### PR TITLE
fix ignore_metadata flag propagation for arrays of structs

### DIFF
--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -115,7 +115,7 @@ def are_datatypes_equal_ignore_nullable(dt1, dt2, ignore_metadata: bool = False)
     if dt1.typeName() == dt2.typeName():
         # Account for array types by inspecting elementType.
         if dt1.typeName() == "array":
-            return are_datatypes_equal_ignore_nullable(dt1.elementType, dt2.elementType)
+            return are_datatypes_equal_ignore_nullable(dt1.elementType, dt2.elementType, ignore_metadata)
         elif dt1.typeName() == "struct":
             return are_schemas_equal_ignore_nullable(dt1, dt2, ignore_metadata)
         else:

--- a/tests/test_structfield_comparer.py
+++ b/tests/test_structfield_comparer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pyspark.sql.types import DoubleType, IntegerType, StructField, StructType
+from pyspark.sql.types import ArrayType, DoubleType, IntegerType, StringType, StructField, StructType
 
 from chispa.structfield_comparer import are_structfields_equal
 
@@ -59,4 +59,29 @@ def describe_are_structfields_equal():
     def it_returns_true_when_inner_metadata_is_different_but_ignored():
         sf1 = StructField("hi", StructType([StructField("world", IntegerType(), False)]), False)
         sf2 = StructField("hi", StructType([StructField("world", IntegerType(), False, {"a": "b"})]), False)
+        assert are_structfields_equal(sf1, sf2, ignore_metadata=True) is True
+
+    def it_returns_true_when_inner_array_metadata_is_different_but_ignored():
+        sf1 = StructField(
+            "hi",
+            ArrayType(
+                StructType([
+                    StructField("world", StringType(), True, {"comment": "Comment"}),
+                    StructField("sunshine", IntegerType(), True),
+                ]),
+                True,
+            ),
+            True,
+        )
+        sf2 = StructField(
+            "hi",
+            ArrayType(
+                StructType([
+                    StructField("world", StringType(), True, {"comment": "Some other comment"}),
+                    StructField("sunshine", IntegerType(), True),
+                ]),
+                True,
+            ),
+            True,
+        )
         assert are_structfields_equal(sf1, sf2, ignore_metadata=True) is True

--- a/tests/test_structfield_comparer.py
+++ b/tests/test_structfield_comparer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pyspark.sql.types import ArrayType, DoubleType, IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import ArrayType, DoubleType, IntegerType, StructField, StructType
 
 from chispa.structfield_comparer import are_structfields_equal
 
@@ -66,8 +66,7 @@ def describe_are_structfields_equal():
             "hi",
             ArrayType(
                 StructType([
-                    StructField("world", StringType(), True, {"comment": "Comment"}),
-                    StructField("sunshine", IntegerType(), True),
+                    StructField("world", IntegerType(), True, {"comment": "Comment"}),
                 ]),
                 True,
             ),
@@ -77,8 +76,7 @@ def describe_are_structfields_equal():
             "hi",
             ArrayType(
                 StructType([
-                    StructField("world", StringType(), True, {"comment": "Some other comment"}),
-                    StructField("sunshine", IntegerType(), True),
+                    StructField("world", IntegerType(), True, {"comment": "Some other comment"}),
                 ]),
                 True,
             ),


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Follow up on #133. 
The ignore_metadata flag wasn't propagating properly for structfields containing an array of structfields.