### PR TITLE
Add ignore_columns option to dataframe_comparer.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,46 @@ Here's the error message you'll see if you run `assert_df_equality(df1, df2)`, w
 
 ![ignore_column_order_false](https://raw.githubusercontent.com/MrPowers/chispa/main/images/ignore_column_order_false.png)
 
+### Ignore specific columns
+
+This section explains how to compare DataFrames, ignoring specific columns.
+
+Suppose you have the following `df1`:
+
+```
++------------+-------------+
+|    name    | clean_name  |
++------------+-------------+
+| "matt7"    |   "matt7"    |
+| "bill&"    |   "bill"    |
+| "isabela*" |   "isabela" |
+| "None"     |   "None"    |
++------------+-------------+
+```
+
+Here are the contents of `df2`:
+
+```
++------------+-------------+
+|    name    | clean_name  |
++------------+-------------+
+| "matt7"    |   "matt"    |
+| "bill&"    |   "bill"    |
+| "isabela*" |   "isabela" |
+| "None"     |   "None"    |
++------------+-------------+
+```
+
+Here's how to compare the equality of `df1` and `df2`, ignoring the column `clean_name`:
+
+```python
+assert_df_equality(df1, df2, ignore_columns=["clean_name"])
+```
+
+Here's the error message you'll see if you run `assert_df_equality(df1, df2)`, without ignoring the column `clean_name`.
+
+![ignore_columns_none](https://raw.githubusercontent.com/MrPowers/chispa/main/images/dfs_not_equal_error.png)
+
 ### Ignore nullability
 
 Each column in a schema has three properties: a name, data type, and nullable property.  The column can accept null values if `nullable` is set to true.

--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -68,6 +68,7 @@ class Chispa:
         ignore_row_order: bool = False,
         underline_cells: bool = False,
         ignore_metadata: bool = False,
+        ignore_columns: list[str] | None = None,
     ) -> None:
         return assert_df_equality(
             df1,
@@ -79,6 +80,7 @@ class Chispa:
             ignore_row_order,
             underline_cells,
             ignore_metadata,
+            ignore_columns,
             self.formats,
         )
 

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -119,11 +119,7 @@ def assert_approx_df_equality(
         )
     elif allow_nan_equality:
         assert_generic_rows_equality(
-            df1.collect(),
-            df2.collect(),
-            are_rows_equal_enhanced,
-            {"allow_nan_equality": True},
-            formats=formats
+            df1.collect(), df2.collect(), are_rows_equal_enhanced, {"allow_nan_equality": True}, formats=formats
         )
     else:
         assert_basic_rows_equality(df1.collect(), df2.collect(), formats=formats)

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -133,6 +133,21 @@ def describe_assert_df_equality():
         with pytest.raises(SchemasNotEqualError):
             assert_df_equality(df1, df2)
 
+    def it_can_ignore_columns():
+        data1 = [("bob", "jose"), ("li", "li"), ("luisa", "laura")]
+        df1 = spark.createDataFrame(data1, ["name", "expected_name"])
+        data2 = [("bob", "jose"), ("li", "boo"), ("luisa", "boo")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        assert_df_equality(df1, df2, ignore_columns=["expected_name"])
+
+    def it_throws_when_dfs_are_not_same_with_ignored_columns():
+        data1 = [("bob", "jose"), ("li", "li"), ("luisa", "laura")]
+        df1 = spark.createDataFrame(data1, ["name", "expected_name"])
+        data2 = [("bob", "jose"), ("li", "boo"), ("luisa", "boo")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert assert_df_equality(df1, df2, ignore_columns=["name"])
+
 
 def describe_are_dfs_equal():
     def it_returns_false_with_schema_mismatches():
@@ -206,3 +221,18 @@ def describe_assert_approx_df_equality():
         ]
         df2 = spark.createDataFrame(data2, ["num", "expected_name"])
         assert_approx_df_equality(df1, df2, 0.1, allow_nan_equality=True)
+
+    def it_can_ignore_columns():
+        data1 = [("bob", "jose"), ("li", "li"), ("luisa", "laura")]
+        df1 = spark.createDataFrame(data1, ["name", "expected_name"])
+        data2 = [("bob", "jose"), ("li", "boo"), ("luisa", "boo")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        assert_approx_df_equality(df1, df2, 0.1, ignore_columns=["expected_name"])
+
+    def it_throws_when_dfs_are_not_same_with_ignored_columns():
+        data1 = [("bob", "jose"), ("li", "li"), ("luisa", "laura")]
+        df1 = spark.createDataFrame(data1, ["name", "expected_name"])
+        data2 = [("bob", "jose"), ("li", "boo"), ("luisa", "boo")]
+        df2 = spark.createDataFrame(data2, ["name", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert assert_approx_df_equality(df1, df2, 0.1, ignore_columns=["name"])


### PR DESCRIPTION
Add ignore_columns option to:
assert_df_equality()
assert_approx_df_equality()

Implementation for #140 

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Often when comparing dataframes we have some columns which can / should be ignored during the equality check. E.g. timestamp columns, or UUID.

With the implementation of ignore_columns option in:
assert_df_equality(),
and
assert_approx_df_equality(),
functions, users can now specify columns to be ignoered during databrame comparison.