### PR TITLE
Add strict data type comparison when nullability/metadata flags

### DIFF
--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -201,6 +201,8 @@ def are_datatypes_equal_ignore_nullable(dt1, dt2, ignore_metadata: bool = False)
         elif dt1.typeName() == "struct":
             return are_schemas_equal_ignore_nullable(dt1, dt2, ignore_metadata)
         else:
-            return True
+            # Some data types have additional attributes (e.g. precision and scale for Decimal),
+            # and the type equality check must also check for equality of these attributes.
+            return vars(dt1) == vars(dt2)
     else:
         return False

--- a/tests/test_schema_comparer.py
+++ b/tests/test_schema_comparer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from pyspark.sql.types import ArrayType, DoubleType, IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import ArrayType, DecimalType, DoubleType, IntegerType, StringType, StructField, StructType
 
 from chispa.schema_comparer import (
     SchemasNotEqualError,
@@ -49,6 +49,48 @@ def describe_assert_schema_equality():
         ])
         with pytest.raises(SchemasNotEqualError):
             assert_schema_equality(s1, s2)
+
+    def it_throws_when_data_types_differ():
+        s1 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 2), True),
+        ])
+        s2 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 3), True),
+        ])
+        with pytest.raises(SchemasNotEqualError):
+            assert_schema_equality(s1, s2)
+
+    def it_throws_when_data_types_differ_with_enabled_ignore_nullability():
+        s1 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 2), True),
+        ])
+        s2 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 3), True),
+        ])
+        with pytest.raises(SchemasNotEqualError):
+            assert_schema_equality(s1, s2, ignore_nullable=True)
+
+    def it_throws_when_data_types_differ_with_enabled_ignore_metadata():
+        s1 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 2), True),
+        ])
+        s2 = StructType([
+            StructField("name", StringType(), True),
+            StructField("age", IntegerType(), True),
+            StructField("height", DecimalType(10, 3), True),
+        ])
+        with pytest.raises(SchemasNotEqualError):
+            assert_schema_equality(s1, s2, ignore_metadata=True)
 
 
 def describe_tree_string():


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This PR addresses an issue with comparing dataframes that contain DecimalType columns.

When using assert_schema_equality with default flag values, strict type validation is required. However, enabling the ignore_nullable flag changes type validation to only check for type name equality. As a result, Decimal(10, 3) is considered equal to Decimal(5, 2).

This PR ensures that type attributes (e.g. precision and scale for DecimalType) are considered in the type comparison process.

Code example to reproduce existing behaviour:
```
from __future__ import annotations

from decimal import Decimal

from chispa.schema_comparer import assert_schema_equality
from pyspark.sql import SparkSession
from pyspark.sql import types as T

spark = SparkSession.builder.master("local").appName("chispa").getOrCreate()

df_1 = spark.createDataFrame(
    data=[{"value": Decimal("2.0")}],
    schema=T.StructType([T.StructField(name="value", dataType=T.DecimalType(10, 5))]),
)

df_2 = spark.createDataFrame(
    data=[{"value": Decimal("2.0")}],
    schema=T.StructType([T.StructField(name="value", dataType=T.DecimalType(10, 2))]),
)

# will fail
assert_schema_equality(df_1.schema, df_2.schema)

# will pass
assert_schema_equality(df_1.schema, df_2.schema, ignore_nullable=True)
```

