### PR TITLE
BugFix: row ordering in assert_df_equality when using ignore_columns with ignore_row_order

### DIFF
--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -42,10 +42,10 @@ def assert_df_equality(
         transforms = []
     if ignore_column_order:
         transforms.append(lambda df: df.select(sorted(df.columns)))
-    if ignore_row_order:
-        transforms.append(lambda df: df.sort(df.columns))
     if ignore_columns:
         transforms.append(lambda df: df.drop(*ignore_columns))
+    if ignore_row_order:
+        transforms.append(lambda df: df.sort(df.columns))
 
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
@@ -99,10 +99,10 @@ def assert_approx_df_equality(
         transforms = []
     if ignore_column_order:
         transforms.append(lambda df: df.select(sorted(df.columns)))
-    if ignore_row_order:
-        transforms.append(lambda df: df.sort(df.columns))
     if ignore_columns:
         transforms.append(lambda df: df.drop(*ignore_columns))
+    if ignore_row_order:
+        transforms.append(lambda df: df.sort(df.columns))
 
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -148,6 +148,13 @@ def describe_assert_df_equality():
         with pytest.raises(DataFramesNotEqualError):
             assert assert_df_equality(df1, df2, ignore_columns=["name"])
 
+    def it_works_when_sorting_and_dropping_columns():
+        data1 = [("b", "jose", 10), ("a", "jose", 20)]
+        df1 = spark.createDataFrame(data1, ["ignore_me", "name", "score"])
+        data2 = [("a", "jose", 10), ("b", "jose", 20)]
+        df2 = spark.createDataFrame(data2, ["ignore_me", "name", "score"])
+        assert_df_equality(df1, df2, ignore_columns=["ignore_me"], ignore_row_order=True)
+
 
 def describe_are_dfs_equal():
     def it_returns_false_with_schema_mismatches():


### PR DESCRIPTION
We discovered a subtle bug in the `assert_df_equality` function. When both `ignore_row_order` and `ignore_columns` are enabled (and optionally `ignore_column_order` as well), the transformation chain currently sorts the DataFrame rows using all columns (including those later dropped by `ignore_columns`). This leads to incorrect row alignment when the ignored columns actually affect tie-breaking in the sort. In real-world usage, this results in the cell-by-cell equality assertion mis-identifying rows as being in a different order—even though the final visible data (after dropping the ignored columns) should be identical.

What was done?

- A new unit test it_works_when_sorting_and_dropping_columns() has been added.
   - The test creates two DataFrames that differ only in the order of values in a column that is later ignored.
- Updated the order of transformations in `assert_df_equality` and `assert_approx_df_equality`

