### PR TITLE
Expose `SchemasNotEqualError` in public API

### DIFF
--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -18,6 +18,7 @@ from .dataframe_comparer import (
     assert_df_equality,
 )
 from .rows_comparer import assert_basic_rows_equality
+from .schema_comparer import SchemasNotEqualError
 
 
 class Chispa:
@@ -65,6 +66,7 @@ __all__ = (
     "DefaultFormats",
     "Format",
     "FormattingConfig",
+    "SchemasNotEqualError",
     "Style",
     "assert_approx_column_equality",
     "assert_approx_df_equality",


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`SchemasNotEqualError` is not exposed as part of the public API. It may be needed for exception handling.

For instance: 

```py
from chispa import SchemasNotEqualError, DataFramesNotEqualError, assert_df_equality

try:
    assert_df_equality(
        df1,
        df2,
    )
except (
    DataFramesNotEqualError,
    SchemasNotEqualError,
):
    # DataFrames are not equal
    # -> data have changed
    print("Handle exception")
```

Currently this exception may be imported from `chispa.schema_comparer` directly (unstable), but that is not best practice as the `chispa/__init__.py` file is what defines the public API (stable)