### PR TITLE
Improvements for PR #100 - ignore_metadata for assert_approx_df_equality

### DIFF
--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -124,8 +124,8 @@ def assert_approx_df_equality(
     allow_nan_equality: bool = False,
     ignore_column_order: bool = False,
     ignore_row_order: bool = False,
-    ignore_columns: list[str] | None = None,
     ignore_metadata: bool = False,
+    ignore_columns: list[str] | None = None,
     formats: FormattingConfig | None = None,
 ) -> None:
     if not formats:

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -125,6 +125,7 @@ def assert_approx_df_equality(
     ignore_column_order: bool = False,
     ignore_row_order: bool = False,
     ignore_columns: list[str] | None = None,
+    ignore_metadata: bool = False,
     formats: FormattingConfig | None = None,
 ) -> None:
     if not formats:
@@ -144,7 +145,7 @@ def assert_approx_df_equality(
     df1 = reduce(lambda acc, fn: fn(acc), transforms, df1)
     df2 = reduce(lambda acc, fn: fn(acc), transforms, df2)
 
-    assert_schema_equality(df1.schema, df2.schema, ignore_nullable)
+    assert_schema_equality(df1.schema, df2.schema, ignore_nullable, ignore_metadata)
 
     if precision != 0:
         assert_generic_rows_equality(

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -287,6 +287,19 @@ def describe_assert_approx_df_equality():
         with pytest.raises(DataFramesNotEqualError):
             assert assert_approx_df_equality(df1, df2, 0.1, ignore_columns=["name"])
 
+    def it_can_ignore_metadata(spark: SparkSession):
+        schema1 = StructType([
+            StructField("num", IntegerType(), True, {"comment": "a"}),
+            StructField("name", StringType(), True),
+        ])
+        schema2 = StructType([
+            StructField("num", IntegerType(), True, {"comment": "b"}),
+            StructField("name", StringType(), True),
+        ])
+        df1 = spark.createDataFrame([(1, "jose"), (2, "li")], schema=schema1)
+        df2 = spark.createDataFrame([(1, "jose"), (2, "li")], schema=schema2)
+        assert_approx_df_equality(df1, df2, 0.1, ignore_metadata=True)
+
     def it_does_not_throw_with_struct_columns_and_ignore_row_order(spark: SparkSession):
         data1 = [((1.0, "jose"),), ((1.1, "li"),)]
         df1 = spark.createDataFrame(data1, ["person"])


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

The #100 started to add support for `ignore_metadata` in `assert_approx_df_equality`, but most of the work was already merged in #182.  This PR fixes the missing piece in the `assert_approx_df_equality` implementation
