### PR TITLE
Support `ignore_row_order=True` for map columns & fields

### DIFF
--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -16,37 +16,43 @@ from chispa.rows_comparer import (
 from chispa.schema_comparer import assert_schema_equality
 
 
-def _get_hashable_columns(df: DataFrame) -> list[int | str | Column]:
-    """Return list of column names that need hash() for sorting.
-
-    Spark's sort() cannot order struct, array, or map types directly.
-    These columns need to be hashed before sorting when ignore_row_order=True.
-    """
-    hashable_cols: list[int | str | Column] = []
-    for field in df.schema.fields:
-        if isinstance(field.dataType, StructType | ArrayType | MapType):
-            hashable_cols.append(field.name)
-    return hashable_cols
+def _contains_map_type(dt: ArrayType | MapType | StructType) -> bool:
+    """Return True if the data type contains a MapType anywhere in its tree."""
+    if isinstance(dt, MapType):
+        return True
+    if isinstance(dt, ArrayType):
+        return isinstance(dt.elementType, (StructType, ArrayType, MapType)) and _contains_map_type(dt.elementType)
+    if isinstance(dt, StructType):
+        return any(
+            isinstance(f.dataType, (StructType, ArrayType, MapType)) and _contains_map_type(f.dataType)
+            for f in dt.fields
+        )
+    return False
 
 
 def _sort_df_for_row_order_comparison(df: DataFrame) -> DataFrame:
     """Sort DataFrame for row-order-insensitive comparison.
 
     For struct/array/map columns, applies hash() before sorting since
-    Spark cannot directly sort these complex types.
+    Spark cannot directly sort these complex types. Columns containing
+    MapType anywhere in their type tree use to_json() before hashing,
+    because Spark's hash() does not support MapType.
     """
-    hash_cols = _get_hashable_columns(df)
-    if not hash_cols:
-        # No complex types, sort normally
-        return df.sort(*df.columns)
-
-    # Build sort expressions: hash complex cols, sort primitive cols normally
-    sort_exprs = []
-    for col_name in df.columns:
-        if col_name in hash_cols:
-            sort_exprs.append(F.hash(F.col(col_name)))
+    sort_exprs: list[Column] = []
+    has_complex = False
+    for field in df.schema.fields:
+        col = F.col(field.name)
+        if isinstance(field.dataType, (StructType, ArrayType, MapType)):
+            has_complex = True
+            if _contains_map_type(field.dataType):
+                sort_exprs.append(F.hash(F.to_json(col)))
+            else:
+                sort_exprs.append(F.hash(col))
         else:
-            sort_exprs.append(F.col(col_name))
+            sort_exprs.append(col)
+
+    if not has_complex:
+        return df.sort(*df.columns)
 
     return df.sort(*sort_exprs)
 

--- a/chispa/dataframe_comparer.py
+++ b/chispa/dataframe_comparer.py
@@ -33,10 +33,9 @@ def _contains_map_type(dt: ArrayType | MapType | StructType) -> bool:
 def _sort_df_for_row_order_comparison(df: DataFrame) -> DataFrame:
     """Sort DataFrame for row-order-insensitive comparison.
 
-    For struct/array/map columns, applies hash() before sorting since
-    Spark cannot directly sort these complex types. Columns containing
-    MapType anywhere in their type tree use to_json() before hashing,
-    because Spark's hash() does not support MapType.
+    Struct/array columns use hash() for efficient sorting. Columns containing
+    MapType anywhere in their type tree use to_json() instead, because Spark's
+    hash() does not support MapType.
     """
     sort_exprs: list[Column] = []
     has_complex = False
@@ -45,7 +44,7 @@ def _sort_df_for_row_order_comparison(df: DataFrame) -> DataFrame:
         if isinstance(field.dataType, (StructType, ArrayType, MapType)):
             has_complex = True
             if _contains_map_type(field.dataType):
-                sort_exprs.append(F.hash(F.to_json(col)))
+                sort_exprs.append(F.to_json(col))
             else:
                 sort_exprs.append(F.hash(col))
         else:

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 from pyspark.sql import SparkSession
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import ArrayType, IntegerType, MapType, StringType, StructField, StructType
 
 from chispa import DataFramesNotEqualError, assert_approx_df_equality, assert_df_equality
 from chispa.dataframe_comparer import are_dfs_equal
@@ -53,6 +53,42 @@ def describe_assert_df_equality():
         df1 = spark.createDataFrame(data1, ["nested_person"])
         data2 = [(((2, "li"), 40),), (((1, "jose"), 30),)]
         df2 = spark.createDataFrame(data2, ["nested_person"])
+        assert_df_equality(df1, df2, ignore_row_order=True)
+
+    def it_can_work_with_map_columns_and_ignore_row_order(spark: SparkSession):
+        schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("props", MapType(StringType(), IntegerType())),
+        ])
+        df1 = spark.createDataFrame([(1, {"a": 10}), (2, {"b": 20})], schema=schema)
+        df2 = spark.createDataFrame([(2, {"b": 20}), (1, {"a": 10})], schema=schema)
+        assert_df_equality(df1, df2, ignore_row_order=True)
+
+    def it_can_work_with_struct_containing_map_and_ignore_row_order(spark: SparkSession):
+        schema = StructType([
+            StructField(
+                "s",
+                StructType([
+                    StructField("name", StringType()),
+                    StructField("props", MapType(StringType(), IntegerType())),
+                ]),
+            )
+        ])
+        df1 = spark.createDataFrame(
+            [({"name": "a", "props": {"k": 1}},), ({"name": "b", "props": {"k": 2}},)], schema=schema
+        )
+        df2 = spark.createDataFrame(
+            [({"name": "b", "props": {"k": 2}},), ({"name": "a", "props": {"k": 1}},)], schema=schema
+        )
+        assert_df_equality(df1, df2, ignore_row_order=True)
+
+    def it_can_work_with_array_of_maps_and_ignore_row_order(spark: SparkSession):
+        schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("items", ArrayType(MapType(StringType(), IntegerType()))),
+        ])
+        df1 = spark.createDataFrame([(1, [{"a": 1}]), (2, [{"b": 2}])], schema=schema)
+        df2 = spark.createDataFrame([(2, [{"b": 2}]), (1, [{"a": 1}])], schema=schema)
         assert_df_equality(df1, df2, ignore_row_order=True)
 
     def it_can_work_with_different_row_and_column_orders(spark: SparkSession):

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -64,6 +64,21 @@ def describe_assert_df_equality():
         df2 = spark.createDataFrame([(2, {"b": 20}), (1, {"a": 10})], schema=schema)
         assert_df_equality(df1, df2, ignore_row_order=True)
 
+    def it_can_work_with_multi_entry_map_columns_and_ignore_row_order(spark: SparkSession):
+        schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("props", MapType(StringType(), IntegerType())),
+        ])
+        df1 = spark.createDataFrame(
+            [(1, {"a": 10, "b": 20}), (2, {"x": 30, "y": 40})],
+            schema=schema,
+        )
+        df2 = spark.createDataFrame(
+            [(2, {"y": 40, "x": 30}), (1, {"b": 20, "a": 10})],
+            schema=schema,
+        )
+        assert_df_equality(df1, df2, ignore_row_order=True)
+
     def it_can_work_with_struct_containing_map_and_ignore_row_order(spark: SparkSession):
         schema = StructType([
             StructField(


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->

There is no `hash` implementation for Map type, so current implementation doesn't work for columns or struct fields with the map type.  This PR fixes that.

Resolves #160
