### PR TITLE
add flatten-dataframe

### DIFF
--- a/chispa/__init__.py
+++ b/chispa/__init__.py
@@ -17,6 +17,7 @@ from .dataframe_comparer import (
     assert_approx_df_equality,
     assert_df_equality,
 )
+from .flatten import flatten_dataframe
 from .rows_comparer import assert_basic_rows_equality
 from .schema_comparer import SchemasNotEqualError
 
@@ -73,4 +74,5 @@ __all__ = (
     "assert_basic_rows_equality",
     "assert_column_equality",
     "assert_df_equality",
+    "flatten_dataframe",
 )

--- a/chispa/flatten.py
+++ b/chispa/flatten.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyspark.sql.functions import col, explode_outer, map_keys
+from pyspark.sql.types import ArrayType, MapType, StructType
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame
+    from pyspark.sql.types import DataType
+
+
+def _complex_fields(schema: StructType) -> dict[str, DataType]:
+    return {
+        field.name: field.dataType
+        for field in schema.fields
+        if isinstance(field.dataType, (StructType, ArrayType, MapType))
+    }
+
+
+def flatten_dataframe(df: DataFrame, sep: str = "_") -> DataFrame:
+    if sep == ".":
+        raise ValueError("`sep` must not be '.', it conflicts with Spark's struct field accessor")
+
+    remaining = _complex_fields(df.schema)
+    while remaining:
+        col_name, dtype = next(iter(remaining.items()))
+
+        if isinstance(dtype, StructType):
+            expanded = [col(f"`{col_name}`.`{f.name}`").alias(f"{col_name}{sep}{f.name}") for f in dtype.fields]
+            df = df.select("*", *expanded).drop(col_name)
+
+        elif isinstance(dtype, ArrayType):
+            df = df.withColumn(col_name, explode_outer(col_name))
+
+        elif isinstance(dtype, MapType):
+            keys_rows = df.select(explode_outer(map_keys(col(col_name))).alias("k")).distinct().collect()
+            keys = [row["k"] for row in keys_rows if row["k"] is not None]
+            key_cols = [col(col_name).getItem(k).alias(f"{col_name}{sep}{k}") for k in keys]
+            df = df.select(*[c for c in df.columns if c != col_name], *key_cols)
+
+        remaining = _complex_fields(df.schema)
+
+    return df

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pytest
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    ArrayType,
+    IntegerType,
+    LongType,
+    MapType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from chispa import flatten_dataframe
+
+
+def describe_flatten_dataframe():
+    def it_flattens_struct_columns(spark: SparkSession):
+        schema = StructType([
+            StructField(
+                "name",
+                StructType([
+                    StructField("first", StringType()),
+                    StructField("last", StringType()),
+                ]),
+            ),
+            StructField("state", StringType()),
+        ])
+        df = spark.createDataFrame([(("James", "Smith"), "OH")], schema)
+
+        flat = flatten_dataframe(df)
+
+        assert sorted(flat.columns) == ["name_first", "name_last", "state"]
+        row = flat.collect()[0]
+        assert row["name_first"] == "James"
+        assert row["name_last"] == "Smith"
+        assert row["state"] == "OH"
+
+    def it_flattens_nested_struct_columns(spark: SparkSession):
+        schema = StructType([
+            StructField(
+                "person",
+                StructType([
+                    StructField(
+                        "name",
+                        StructType([
+                            StructField("first", StringType()),
+                        ]),
+                    ),
+                    StructField("age", IntegerType()),
+                ]),
+            ),
+        ])
+        df = spark.createDataFrame([((("Anna",), 30),)], schema)  # type: ignore[arg-type]
+
+        flat = flatten_dataframe(df)
+
+        assert sorted(flat.columns) == ["person_age", "person_name_first"]
+
+    def it_explodes_array_columns(spark: SparkSession):
+        schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("tags", ArrayType(StringType())),
+        ])
+        df = spark.createDataFrame([(1, ["a", "b"]), (2, ["c"])], schema)
+
+        flat = flatten_dataframe(df)
+
+        assert flat.columns == ["id", "tags"]
+        rows = sorted((r["id"], r["tags"]) for r in flat.collect())
+        assert rows == [(1, "a"), (1, "b"), (2, "c")]
+
+    def it_flattens_map_columns_into_one_column_per_key(spark: SparkSession):
+        schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("attrs", MapType(StringType(), StringType())),
+        ])
+        df = spark.createDataFrame([(1, {"color": "red", "size": "L"})], schema)
+
+        flat = flatten_dataframe(df)
+
+        assert sorted(flat.columns) == ["attrs_color", "attrs_size", "id"]
+        row = flat.collect()[0]
+        assert row["attrs_color"] == "red"
+        assert row["attrs_size"] == "L"
+
+    def it_handles_mixed_struct_array_and_map(spark: SparkSession):
+        schema = StructType([
+            StructField("state", StringType()),
+            StructField("info", MapType(StringType(), StringType())),
+            StructField(
+                "counties",
+                ArrayType(
+                    StructType([
+                        StructField("name", StringType()),
+                        StructField("population", LongType()),
+                    ])
+                ),
+            ),
+        ])
+        df = spark.createDataFrame(
+            [("FL", {"governor": "Rick"}, [("Dade", 12345), ("Broward", 40000)])],
+            schema,
+        )
+
+        flat = flatten_dataframe(df)
+
+        assert sorted(flat.columns) == ["counties_name", "counties_population", "info_governor", "state"]
+        rows = sorted((r["state"], r["counties_name"], r["counties_population"]) for r in flat.collect())
+        assert rows == [("FL", "Broward", 40000), ("FL", "Dade", 12345)]
+
+    def it_uses_a_custom_separator(spark: SparkSession):
+        schema = StructType([
+            StructField(
+                "name",
+                StructType([
+                    StructField("first", StringType()),
+                ]),
+            ),
+        ])
+        df = spark.createDataFrame([(("Anna",),)], schema)  # type: ignore[arg-type]
+
+        flat = flatten_dataframe(df, sep=":")
+
+        assert flat.columns == ["name:first"]
+
+    def it_rejects_dot_separator(spark: SparkSession):
+        df = spark.createDataFrame([(1,)], ["x"])
+        with pytest.raises(ValueError, match=r"must not be '\.'"):
+            flatten_dataframe(df, sep=".")
+
+    def it_returns_unchanged_df_when_no_nested_columns(spark: SparkSession):
+        df = spark.createDataFrame([(1, "a"), (2, "b")], ["id", "name"])
+
+        flat = flatten_dataframe(df)
+
+        assert flat.columns == ["id", "name"]
+        assert flat.collect() == df.collect()


### PR DESCRIPTION
Closes #47.     

Adds a new public helper chispa.flatten_dataframe(df, sep="_") that turns a DataFrame containing nested columns into a fully flat one. It walks the schema and, for each complex     
field:
                                                                                                                                                                                     
- StructType → expands every sub-field into its own top-level column named <parent><sep><child> (e.g. name.firstname → name_firstname).                                              
- ArrayType → applies explode_outer, so each element becomes its own row (null-preserving).
- MapType → collects the distinct keys present in the column and turns each into a <parent><sep><key> column.                                                                        
                                                                                                                                                                                     
The walk repeats until no nested types remain, so deeply nested / mixed schemas (struct of map of array of struct, etc.) are flattened in one call. 