### PR TITLE
test: reach 100% coverage and enforce it in CI

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -19,6 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up python
+      id: setup-python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
@@ -43,8 +44,13 @@ runs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.pyspark-version }}-${{ inputs.with-docs }}-${{ hashFiles('poetry.lock') }}
+        # Key on the resolved patch version, not the `3.11` input. A venv symlinks
+        # its interpreter, so when the runner image bumps its Python patch the cached
+        # venv points at a path that no longer exists and poetry discards it.
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.pyspark-version }}-${{ inputs.with-docs }}-${{ hashFiles('poetry.lock') }}
 
+    # Runs unconditionally: on a cache hit this is a fast no-op, and it repairs the
+    # venv if poetry had to recreate it. Skipping it on a hit leaves an empty venv.
     - name: Install dependencies
       run: |
         if [[ "${{ inputs.with-docs }}" == "true" ]]; then
@@ -54,7 +60,6 @@ runs:
         fi
         poetry run pip install pyspark==${{ inputs.pyspark-version }}
       shell: bash
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
     - name: Print python and pyspark version
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Run tests
         run: poetry run pytest tests
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
+        with:
+          # Pin a version the `test` matrix also covers, so coverage is never
+          # measured against a pyspark the suite is not otherwise run on.
+          pyspark-version: "4.0.2"
+
+      # Fails when coverage drops below the `fail_under` set in pyproject.toml.
+      - name: Run tests with coverage
+        run: poetry run make test
+
   check-docs:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ check: ## Run code quality checks
 .PHONY: test
 test: ## Run unit tests
 	@echo "Running unit tests"
-	@poetry run pytest tests --cov=chispa --cov-report=term
+	@poetry run pytest tests --cov --cov-report=term-missing
 
 .PHONY: test-cov-html
 test-cov-html: ## Run unit tests and create a coverage report
 	@echo "Running unit tests and generating HTML report"
-	@poetry run pytest tests --cov=chispa --cov-report=html
+	@poetry run pytest tests --cov --cov-report=html
 
 .PHONY: test-cov-xml
 test-cov-xml: ## Run unit tests and create a coverage report in xml format
 	@echo "Running unit tests and generating XML report"
-	@poetry run pytest tests --cov=chispa --cov-report=xml
+	@poetry run pytest tests --cov --cov-report=xml
 
 .PHONY: build
 build: clean-build ## Build wheel and sdist files using Poetry

--- a/chispa/flatten.py
+++ b/chispa/flatten.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from pyspark.sql import DataFrame
 from pyspark.sql.functions import col, explode_outer, map_keys
-from pyspark.sql.types import ArrayType, MapType, StructType
-
-if TYPE_CHECKING:
-    from pyspark.sql import DataFrame
-    from pyspark.sql.types import DataType
+from pyspark.sql.types import ArrayType, DataType, MapType, StructType
 
 
 def _complex_fields(schema: StructType) -> dict[str, DataType]:
@@ -33,7 +28,7 @@ def flatten_dataframe(df: DataFrame, sep: str = "_") -> DataFrame:
         elif isinstance(dtype, ArrayType):
             df = df.withColumn(col_name, explode_outer(col_name))
 
-        elif isinstance(dtype, MapType):
+        elif isinstance(dtype, MapType):  # pragma: no branch — _complex_fields yields only these three types
             keys_rows = df.select(explode_outer(map_keys(col(col_name))).alias("k")).distinct().collect()
             keys = [row["k"] for row in keys_rows if row["k"] is not None]
             key_cols = [col(col_name).getItem(k).alias(f"{col_name}{sep}{k}") for k in keys]

--- a/chispa/schema_comparer.py
+++ b/chispa/schema_comparer.py
@@ -189,7 +189,7 @@ def _compare_datatypes(
             _compare_struct_fields(dt1, dt2, ignore_nullable, ignore_metadata, indent, lines)
         elif tn1 == TypeName.ARRAY:
             _compare_array_types(dt1, dt2, ignore_nullable, ignore_metadata, indent, lines)
-        elif tn1 == TypeName.MAP:
+        elif tn1 == TypeName.MAP:  # pragma: no branch — tn1 is already known to be in _COMPLEX_TYPES
             _compare_map_types(dt1, dt2, ignore_nullable, ignore_metadata, indent, lines)
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,14 @@ strict = true
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
 
+[tool.coverage.run]
+source = ["chispa"]
+branch = true
+
+[tool.coverage.report]
+# The suite covers every statement and branch; keep it that way.
+fail_under = 100
+
 [tool.mypy]
 files = ["chispa"]
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ branch = true
 
 [tool.coverage.report]
 # The suite covers every statement and branch; keep it that way.
-fail_under = 100
+fail_under = 85
 
 [tool.mypy]
 files = ["chispa"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ branch = true
 
 [tool.coverage.report]
 # The suite covers every statement and branch; keep it that way.
-fail_under = 85
+fail_under = 100
 
 [tool.mypy]
 files = ["chispa"]

--- a/tests/formatting/test_formats.py
+++ b/tests/formatting/test_formats.py
@@ -97,3 +97,29 @@ def test_format_from_list_empty():
     format_instance = Format.from_list(values)
     assert format_instance.color is None
     assert format_instance.style is None
+
+
+def test_format_from_dict_non_dict_input():
+    with pytest.raises(ValueError) as exc_info:
+        Format.from_dict("blue")
+    assert str(exc_info.value) == "Input must be a dictionary"
+
+
+def test_format_from_dict_color_as_list():
+    with pytest.raises(TypeError) as exc_info:
+        Format.from_dict({"color": ["blue"]})
+    assert str(exc_info.value) == "The value for key 'color' should be a string, not a list!"
+
+
+def test_format_from_dict_with_enum_members():
+    format_instance = Format.from_dict({"color": Color.GREEN, "style": Style.BOLD})
+    assert format_instance.color == Color.GREEN
+    assert format_instance.style == [Style.BOLD]
+
+
+def test_get_color_enum_returns_none_for_non_string():
+    assert Format._get_color_enum(None) is None
+
+
+def test_get_style_enum_returns_none_for_non_string():
+    assert Format._get_style_enum(None) is None

--- a/tests/formatting/test_formatting_config.py
+++ b/tests/formatting/test_formatting_config.py
@@ -74,6 +74,12 @@ def test_invalid_style():
     )
 
 
+def test_invalid_format_type():
+    with pytest.raises(ValueError) as exc_info:
+        FormattingConfig(mismatched_rows=["red"])
+    assert str(exc_info.value) == "Invalid format type. Must be Format or dict."
+
+
 def test_invalid_key():
     try:
         FormattingConfig(mismatched_rows={"invalid_key": "value"})

--- a/tests/test_chispa.py
+++ b/tests/test_chispa.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from pyspark.sql import SparkSession
+
+from chispa import Chispa, DataFramesNotEqualError
+from chispa.default_formats import DefaultFormats
+from chispa.formatting import Color, FormattingConfig, Style
+
+
+def describe_chispa():
+    def it_falls_back_to_the_default_formats():
+        chispa = Chispa()
+        assert chispa.formats.mismatched_rows.color == Color.RED
+        assert chispa.formats.matched_rows.color == Color.BLUE
+        assert chispa.formats.mismatched_cells.style == [Style.UNDERLINE]
+
+    def it_keeps_a_formatting_config_as_is():
+        formats = FormattingConfig(mismatched_rows={"color": "green"})
+        chispa = Chispa(formats)
+        assert chispa.formats is formats
+
+    def it_converts_an_arbitrary_dataclass_to_a_formatting_config():
+        chispa = Chispa(DefaultFormats())
+        assert isinstance(chispa.formats, FormattingConfig)
+        assert chispa.formats.mismatched_rows.color == Color.RED
+
+    def it_does_not_throw_when_dfs_are_equal(spark: SparkSession):
+        data = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data, ["num", "name"])
+        df2 = spark.createDataFrame(data, ["num", "name"])
+        Chispa().assert_df_equality(df1, df2)
+
+    def it_throws_when_dfs_are_not_equal(spark: SparkSession):
+        df1 = spark.createDataFrame([(1, "jose"), (2, "li")], ["num", "name"])
+        df2 = spark.createDataFrame([(1, "jose"), (2, "laura")], ["num", "name"])
+        with pytest.raises(DataFramesNotEqualError):
+            Chispa().assert_df_equality(df1, df2)

--- a/tests/test_dataframe_comparer.py
+++ b/tests/test_dataframe_comparer.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass, field
 
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType, IntegerType, MapType, StringType, StructField, StructType
 
 from chispa import DataFramesNotEqualError, assert_approx_df_equality, assert_df_equality
-from chispa.dataframe_comparer import are_dfs_equal
+from chispa.dataframe_comparer import _contains_map_type, are_dfs_equal
+from chispa.formatting import Color, FormattingConfig
 from chispa.schema_comparer import SchemasNotEqualError
+
+
+@dataclass
+class ArbitraryFormats:
+    """Deliberately uses colors that differ from the built-in defaults, so the output can be told apart."""
+
+    mismatched_rows: list[str] = field(default_factory=lambda: ["green"])
+    matched_rows: list[str] = field(default_factory=lambda: ["cyan"])
+    mismatched_cells: list[str] = field(default_factory=lambda: ["purple"])
+    matched_cells: list[str] = field(default_factory=lambda: ["yellow"])
 
 
 def describe_assert_df_equality():
@@ -242,6 +254,16 @@ def describe_assert_df_equality():
         with pytest.raises(DataFramesNotEqualError):
             assert assert_df_equality(df1, df2, ignore_columns=["name"])
 
+    def it_converts_an_arbitrary_dataclass_to_a_formatting_config(spark: SparkSession):
+        df1 = spark.createDataFrame([(1, "jose"), (2, "li")], ["num", "expected_name"])
+        df2 = spark.createDataFrame([(1, "jose"), (2, "laura")], ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError) as exc_info:
+            assert_df_equality(df1, df2, formats=ArbitraryFormats())
+        message = str(exc_info.value)
+        assert Color.PURPLE.value in message
+        assert Color.YELLOW.value in message
+        assert Color.RED.value not in message
+
     def it_works_when_sorting_and_dropping_columns(spark: SparkSession):
         data1 = [("b", "jose", 10), ("a", "jose", 20)]
         df1 = spark.createDataFrame(data1, ["ignore_me", "name", "score"])
@@ -344,3 +366,64 @@ def describe_assert_approx_df_equality():
         data2 = [((1.1, "li"),), ((1.0, "jose"),)]
         df2 = spark.createDataFrame(data2, ["person"])
         assert_approx_df_equality(df1, df2, 0.1, ignore_row_order=True)
+
+    def it_converts_an_arbitrary_dataclass_to_a_formatting_config(spark: SparkSession):
+        df1 = spark.createDataFrame([(1.0, "jose"), (2.0, "li")], ["num", "expected_name"])
+        df2 = spark.createDataFrame([(1.0, "jose"), (2.0, "laura")], ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError) as exc_info:
+            assert_approx_df_equality(df1, df2, 0.1, formats=ArbitraryFormats())
+        message = str(exc_info.value)
+        assert Color.PURPLE.value in message
+        assert Color.CYAN.value in message
+        assert Color.RED.value not in message
+
+    def it_keeps_a_formatting_config_as_is(spark: SparkSession):
+        data = [(1.0, "jose"), (1.1, "li")]
+        df1 = spark.createDataFrame(data, ["num", "expected_name"])
+        df2 = spark.createDataFrame(data, ["num", "expected_name"])
+        assert_approx_df_equality(df1, df2, 0.1, formats=FormattingConfig(mismatched_rows={"color": "green"}))
+
+    def it_does_not_throw_on_schema_column_order_mismatch_with_transforms(spark: SparkSession):
+        data = [(1.0, "jose"), (1.1, "li")]
+        df1 = spark.createDataFrame(data, ["num", "expected_name"])
+        df2 = spark.createDataFrame([(v, n) for n, v in data], ["expected_name", "num"])
+        assert_approx_df_equality(df1, df2, 0.1, transforms=[lambda df: df.select(sorted(df.columns))])
+
+    def it_falls_back_to_exact_comparison_with_zero_precision(spark: SparkSession):
+        data = [(1.0, "jose"), (1.1, "li")]
+        df1 = spark.createDataFrame(data, ["num", "expected_name"])
+        df2 = spark.createDataFrame(data, ["num", "expected_name"])
+        assert_approx_df_equality(df1, df2, 0)
+
+    def it_throws_with_zero_precision_and_a_content_mismatch(spark: SparkSession):
+        df1 = spark.createDataFrame([(1.0, "jose")], ["num", "expected_name"])
+        df2 = spark.createDataFrame([(1.1, "jose")], ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert_approx_df_equality(df1, df2, 0)
+
+    def it_can_consider_nan_values_equal_with_zero_precision(spark: SparkSession):
+        data = [(1.0, "jose"), (float("nan"), "li")]
+        df1 = spark.createDataFrame(data, ["num", "expected_name"])
+        df2 = spark.createDataFrame(data, ["num", "expected_name"])
+        assert_approx_df_equality(df1, df2, 0, allow_nan_equality=True)
+
+    def it_throws_with_zero_precision_nan_equality_and_a_content_mismatch(spark: SparkSession):
+        df1 = spark.createDataFrame([(float("nan"), "jose")], ["num", "expected_name"])
+        df2 = spark.createDataFrame([(float("nan"), "li")], ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert_approx_df_equality(df1, df2, 0, allow_nan_equality=True)
+
+
+def describe_contains_map_type():
+    def it_returns_false_for_a_non_complex_type():
+        assert _contains_map_type(IntegerType()) is False
+
+    def it_returns_true_for_a_map_nested_in_an_array():
+        assert _contains_map_type(ArrayType(MapType(StringType(), IntegerType()))) is True
+
+    def it_returns_false_for_an_array_without_maps():
+        assert _contains_map_type(ArrayType(ArrayType(IntegerType()))) is False
+
+    def it_returns_true_for_a_map_nested_in_a_struct():
+        dt = StructType([StructField("m", MapType(StringType(), IntegerType()), True)])
+        assert _contains_map_type(dt) is True

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -5,11 +5,16 @@ from dataclasses import dataclass
 
 import pytest
 from pyspark.sql import SparkSession
+from pyspark.sql.types import ArrayType, StringType, StructField, StructType
 
 from chispa import DataFramesNotEqualError, assert_basic_rows_equality
 from chispa.bcolors import bcolors, blue, underline_text
 from chispa.default_formats import DefaultFormats
 from chispa.formatting import FormattingConfig
+from chispa.schema_comparer import (
+    are_datatypes_equal_ignore_nullable,
+    are_schemas_equal_ignore_nullable,
+)
 
 
 def test_default_formats_deprecation_warning():
@@ -66,6 +71,20 @@ def test_invalid_value_in_default_formats():
 
     with pytest.raises(ValueError):
         FormattingConfig._from_arbitrary_dataclass(InvalidFormats())
+
+
+def test_are_schemas_equal_ignore_nullable_deprecation():
+    s1 = StructType([StructField("name", StringType(), True)])
+    s2 = StructType([StructField("name", StringType(), False)])
+    with pytest.warns(DeprecationWarning, match="are_schemas_equal_ignore_nullable is deprecated"):
+        assert are_schemas_equal_ignore_nullable(s1, s2) is True
+
+
+def test_are_datatypes_equal_ignore_nullable_deprecation():
+    dt1 = ArrayType(StringType(), True)
+    dt2 = ArrayType(StringType(), False)
+    with pytest.warns(DeprecationWarning, match="are_datatypes_equal_ignore_nullable is deprecated"):
+        assert are_datatypes_equal_ignore_nullable(dt1, dt2) is True
 
 
 def test_bcolors_deprecation():

--- a/tests/test_number_helpers.py
+++ b/tests/test_number_helpers.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from chispa.number_helpers import nan_safe_approx_equality, nan_safe_equality
+
+
+def test_nan_safe_equality():
+    assert nan_safe_equality(float("nan"), float("nan")) is True
+    assert nan_safe_equality(["101", "2"], ["10", "2"]) is False
+
+
+def test_nan_safe_approx_equality():
+    # a difference exactly equal to the precision is within tolerance
+    assert nan_safe_approx_equality(10, 5, 5.0) is True
+    assert nan_safe_approx_equality(10, 9, 5.0) is True
+    assert nan_safe_approx_equality(10, 5, 4.0) is False
+    # nan - nan is nan, so only the isnan check can make these equal
+    assert nan_safe_approx_equality(float("nan"), float("nan"), 5.0) is True
+    assert nan_safe_approx_equality(float("nan"), 5, 5.0) is False

--- a/tests/test_row_comparer.py
+++ b/tests/test_row_comparer.py
@@ -1,44 +1,105 @@
 from __future__ import annotations
 
+import pytest
 from pyspark.sql import Row
 
 from chispa.row_comparer import are_rows_approx_equal, are_rows_equal, are_rows_equal_enhanced
 
 
-def test_are_rows_equal():
-    assert are_rows_equal(Row("bob", "jose"), Row("li", "li")) is False
-    assert are_rows_equal(Row("luisa", "laura"), Row("luisa", "laura")) is True
-    assert are_rows_equal(Row(None, None), Row(None, None)) is True
+@pytest.mark.parametrize(
+    ("r1", "r2", "expected"),
+    [
+        pytest.param(Row("bob", "jose"), Row("li", "li"), False, id="different values"),
+        pytest.param(Row("luisa", "laura"), Row("luisa", "laura"), True, id="identical values"),
+        pytest.param(Row(None, None), Row(None, None), True, id="None values"),
+    ],
+)
+def test_are_rows_equal(r1, r2, expected):
+    assert are_rows_equal(r1, r2) is expected
 
 
-def test_are_rows_equal_enhanced():
-    assert are_rows_equal_enhanced(Row(n1="bob", n2="jose"), Row(n1="li", n2="li"), False) is False
-    assert are_rows_equal_enhanced(Row(n1="luisa", n2="laura"), Row(n1="luisa", n2="laura"), False) is True
-    assert are_rows_equal_enhanced(Row(n1=None, n2=None), Row(n1=None, n2=None), False) is True
-
-    assert are_rows_equal_enhanced(Row(n1="bob", n2="jose"), Row(n1="li", n2="li"), True) is False
-    assert are_rows_equal_enhanced(Row(n1=float("nan"), n2="jose"), Row(n1=float("nan"), n2="jose"), True) is True
-    assert are_rows_equal_enhanced(Row(n1=float("nan"), n2="jose"), Row(n1="hi", n2="jose"), True) is False
-    assert (
-        are_rows_equal_enhanced(
+@pytest.mark.parametrize(
+    ("r1", "r2", "allow_nan_equality", "expected"),
+    [
+        pytest.param(Row(n1="bob", n2="jose"), Row(n1="li", n2="li"), False, False, id="different values"),
+        pytest.param(Row(n1="luisa", n2="laura"), Row(n1="luisa", n2="laura"), False, True, id="identical values"),
+        pytest.param(Row(n1=None, n2=None), Row(n1=None, n2=None), False, True, id="None values"),
+        pytest.param(None, None, False, True, id="both rows missing"),
+        pytest.param(Row(n1="Alex", n2="Bob"), None, False, False, id="one row missing"),
+        pytest.param(
+            Row(n1="Alex", n2="Bob", n3=["Shadow"]),
+            Row(n1="Alex", n2="Bob", n3=["Shadow", "Sky"]),
+            True,
+            False,
+            id="lists of different lengths",
+        ),
+        pytest.param(Row(n1=("Shadow",)), Row(n1=("Shadow", "Sky")), True, False, id="tuples of different lengths"),
+        pytest.param(Row(n1=("Shadow", "Sky")), Row(n1=("Shadow", "Sky")), True, True, id="identical tuples"),
+        pytest.param(
+            Row(n1="bob", n2="jose"), Row(n1="li", n2="li"), True, False, id="different values with nan equality"
+        ),
+        pytest.param(Row(n1=float("nan"), n2="jose"), Row(n1=float("nan"), n2="jose"), True, True, id="matching nans"),
+        pytest.param(Row(n1=float("nan"), n2="jose"), Row(n1="hi", n2="jose"), True, False, id="nan vs non-nan"),
+        pytest.param(
             Row(nested=[[1.0, float("nan")], [3.0, 4.0]], name="jose"),
             Row(nested=[[1.0, float("nan")], [3.0, 4.0]], name="jose"),
             True,
-        )
-        is True
-    )
-    assert (
-        are_rows_equal_enhanced(
+            True,
+            id="nested lists with nans in the same position",
+        ),
+        pytest.param(
             Row(nested=[[1.0, float("nan")], [3.0, 4.0]], name="jose"),
             Row(nested=[[float("nan"), 1.0], [3.0, 4.0]], name="jose"),
             True,
-        )
-        is False
-    )
+            False,
+            id="nested lists with nans in different positions",
+        ),
+    ],
+)
+def test_are_rows_equal_enhanced(r1, r2, allow_nan_equality, expected):
+    assert are_rows_equal_enhanced(r1, r2, allow_nan_equality) is expected
 
 
-def test_are_rows_approx_equal():
-    assert are_rows_approx_equal(Row(num=1.1, first_name="li"), Row(num=1.05, first_name="li"), 0.1) is True
-    assert are_rows_approx_equal(Row(num=5.0, first_name="laura"), Row(num=5.0, first_name="laura"), 0.1) is True
-    assert are_rows_approx_equal(Row(num=5.0, first_name="laura"), Row(num=5.9, first_name="laura"), 0.1) is False
-    assert are_rows_approx_equal(Row(num=None, first_name=None), Row(num=None, first_name=None), 0.1) is True
+@pytest.mark.parametrize(
+    ("r1", "r2", "precision", "allow_nan_equality", "expected"),
+    [
+        pytest.param(
+            Row(num=1.1, first_name="li"), Row(num=1.05, first_name="li"), 0.1, False, True, id="within precision"
+        ),
+        pytest.param(
+            Row(num=5.0, first_name="laura"), Row(num=5.0, first_name="laura"), 0.1, False, True, id="identical values"
+        ),
+        pytest.param(
+            Row(num=5.0, first_name="laura"),
+            Row(num=5.9, first_name="laura"),
+            0.1,
+            False,
+            False,
+            id="outside precision",
+        ),
+        pytest.param(
+            Row(num=None, first_name=None), Row(num=None, first_name=None), 0.1, False, True, id="None values"
+        ),
+        pytest.param(None, None, 0.1, False, True, id="both rows missing"),
+        pytest.param(Row(num=10, first_name="Vlad"), None, 0.1, False, False, id="one row missing"),
+        pytest.param(
+            Row(num=10.5, first_name="Vlad"),
+            Row(num=10.0, first_name="Vlad"),
+            0.1,
+            True,
+            False,
+            id="outside precision with nan equality",
+        ),
+        pytest.param(
+            Row(num=10.5, first_name="Vlad"),
+            Row(num=float("nan"), first_name="Vlad"),
+            0.1,
+            False,
+            False,
+            id="nan vs number",
+        ),
+        pytest.param(Row(first_name="Alex"), Row(first_name="El"), 0.1, False, False, id="different strings"),
+    ],
+)
+def test_are_rows_approx_equal(r1, r2, precision, allow_nan_equality, expected):
+    assert are_rows_approx_equal(r1, r2, precision, allow_nan_equality) is expected

--- a/tests/test_rows_comparer.py
+++ b/tests/test_rows_comparer.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 import pytest
 from pyspark.sql import SparkSession
 
 from chispa import DataFramesNotEqualError, assert_basic_rows_equality
+from chispa.formatting import Color, Style
+from chispa.row_comparer import are_rows_equal_enhanced
+from chispa.rows_comparer import assert_generic_rows_equality
+
+
+@dataclass
+class ArbitraryFormats:
+    """Deliberately uses colors that differ from the built-in defaults, so the output can be told apart."""
+
+    mismatched_rows: list[str] = field(default_factory=lambda: ["green"])
+    matched_rows: list[str] = field(default_factory=lambda: ["cyan"])
+    mismatched_cells: list[str] = field(default_factory=lambda: ["purple"])
+    matched_cells: list[str] = field(default_factory=lambda: ["yellow"])
 
 
 def describe_assert_basic_rows_equality():
@@ -29,3 +44,60 @@ def describe_assert_basic_rows_equality():
         data2 = [(1, "jose"), (2, "li"), (3, "laura")]
         df2 = spark.createDataFrame(data2, ["name", "expected_name"])
         assert_basic_rows_equality(df1.collect(), df2.collect())
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: fields are zipped positionally but looked up by name, so with duplicate "
+            "column names every lookup returns the first match and real differences go unreported."
+        ),
+    )
+    def it_throws_when_duplicate_column_names_hide_a_mismatch(spark: SparkSession):
+        df1 = spark.createDataFrame([(1, 2)], ["a", "a"])
+        df2 = spark.createDataFrame([(1, 999)], ["a", "a"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert_basic_rows_equality(df1.collect(), df2.collect())
+
+    def it_throws_when_the_first_df_has_fewer_rows(spark: SparkSession):
+        data1 = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [(1, "jose"), (2, "li"), (3, "laura")]
+        df2 = spark.createDataFrame(data2, ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError):
+            assert_basic_rows_equality(df1.collect(), df2.collect())
+
+
+def describe_assert_generic_rows_equality():
+    def it_uses_default_formats_when_none_are_given(spark: SparkSession):
+        data1 = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [(1, "jose"), (2, "laura")]
+        df2 = spark.createDataFrame(data2, ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError) as exc_info:
+            assert_generic_rows_equality(
+                df1.collect(), df2.collect(), are_rows_equal_enhanced, {"allow_nan_equality": True}
+            )
+        message = str(exc_info.value)
+        # the defaults are red (underlined for cells) for mismatches and blue for matches
+        assert Color.RED.value in message
+        assert Style.UNDERLINE.value in message
+        assert Color.BLUE.value in message
+        assert Color.PURPLE.value not in message
+
+    def it_converts_an_arbitrary_dataclass_to_a_formatting_config(spark: SparkSession):
+        data1 = [(1, "jose"), (2, "li")]
+        df1 = spark.createDataFrame(data1, ["num", "expected_name"])
+        data2 = [(1, "jose"), (2, "laura")]
+        df2 = spark.createDataFrame(data2, ["num", "expected_name"])
+        with pytest.raises(DataFramesNotEqualError) as exc_info:
+            assert_generic_rows_equality(
+                df1.collect(),
+                df2.collect(),
+                are_rows_equal_enhanced,
+                {"allow_nan_equality": True},
+                formats=ArbitraryFormats(),
+            )
+        message = str(exc_info.value)
+        assert Color.PURPLE.value in message
+        assert Color.CYAN.value in message
+        assert Color.RED.value not in message

--- a/tests/test_schema_comparer.py
+++ b/tests/test_schema_comparer.py
@@ -12,14 +12,31 @@ from pyspark.sql.types import (
     StructType,
 )
 
+from chispa.bcolors import bcolors
+from chispa.common_enums import OutputFormat
 from chispa.schema_comparer import (
     SchemasNotEqualError,
+    _are_fields_shallow_equal,
+    _compare_array_types,
+    _compare_map_types,
     are_schemas_equal,
     are_structfields_equal,
     assert_schema_equality,
     assert_schema_equality_ignore_nullable,
     create_schema_comparison_tree,
+    print_schema_diff,
 )
+
+
+def _tree_line(tree: str, needle: str) -> str:
+    """Return the single line of a comparison tree containing `needle`.
+
+    Both schemas are printed side by side on one line, which is colored red when they
+    differ and blue when they match, so the color of the line is the actual assertion.
+    """
+    matches = [line for line in tree.split("\n") if needle in line]
+    assert len(matches) == 1, f"expected exactly one line containing {needle!r}, found {len(matches)}"
+    return matches[0]
 
 
 def describe_assert_schema_equality():
@@ -923,3 +940,123 @@ def describe_are_schemas_equal():
         s1 = StructType([StructField("m", MapType(StringType(), IntegerType(), True), True)])
         s2 = StructType([StructField("m", MapType(StringType(), IntegerType(), False), True)])
         assert are_schemas_equal(s1, s2, ignore_nullable=True) is True
+
+
+def describe_print_schema_diff():
+    def it_prints_a_table(capsys):
+        s1 = StructType([StructField("name", StringType(), True)])
+        s2 = StructType([StructField("nombre", StringType(), True)])
+        print_schema_diff(s1, s2, ignore_nullable=False, ignore_metadata=False)
+        captured = capsys.readouterr()
+        assert "schema1" in captured.out
+        assert "schema2" in captured.out
+
+    def it_prints_a_tree(capsys):
+        s1 = StructType([StructField("name", StringType(), True)])
+        s2 = StructType([StructField("nombre", StringType(), True)])
+        print_schema_diff(s1, s2, ignore_nullable=False, ignore_metadata=False, output_format=OutputFormat.TREE)
+        captured = capsys.readouterr()
+        assert "|-- name: string" in captured.out
+        assert "|-- nombre: string" in captured.out
+
+    def it_throws_with_an_unknown_output_format():
+        s1 = StructType([StructField("name", StringType(), True)])
+        s2 = StructType([StructField("name", StringType(), True)])
+        with pytest.raises(ValueError):
+            print_schema_diff(s1, s2, ignore_nullable=False, ignore_metadata=False, output_format="invalid")
+
+
+def describe_create_schema_comparison_tree():
+    def it_handles_empty_schemas():
+        result = create_schema_comparison_tree(StructType([]), StructType([]), False, False)
+        assert "schema1" in result
+        assert "schema2" in result
+
+    def it_marks_leaf_types_with_different_type_names_as_unequal():
+        s1 = StructType([StructField("num", IntegerType(), True)])
+        s2 = StructType([StructField("num", StringType(), True)])
+        line = _tree_line(create_schema_comparison_tree(s1, s2, False, False), "|-- num: int")
+        assert "|-- num: string" in line
+        assert line.startswith(bcolors.LightRed)
+
+    def it_marks_fields_with_different_nullability_as_unequal():
+        s1 = StructType([StructField("name", StringType(), True)])
+        s2 = StructType([StructField("name", StringType(), False)])
+        line = _tree_line(create_schema_comparison_tree(s1, s2, False, False), "|-- name: string")
+        assert "(nullable = true)" in line
+        assert "(nullable = false)" in line
+        assert line.startswith(bcolors.LightRed)
+
+    def it_marks_maps_with_different_key_types_as_unequal():
+        s1 = StructType([StructField("m", MapType(StringType(), IntegerType(), True), True)])
+        s2 = StructType([StructField("m", MapType(IntegerType(), IntegerType(), True), True)])
+        result = create_schema_comparison_tree(s1, s2, False, False)
+        key_line = _tree_line(result, "|-- key:")
+        assert "|-- key: string" in key_line
+        assert "|-- key: int" in key_line
+        assert key_line.startswith(bcolors.LightRed)
+        # only the key type differs, so the value line is still marked as equal
+        assert _tree_line(result, "|-- value:").startswith(bcolors.LightBlue)
+
+
+def describe_are_fields_shallow_equal():
+    def it_returns_true_when_both_fields_are_missing():
+        assert _are_fields_shallow_equal(None, None, False, False) is True
+
+    def it_returns_false_when_only_one_field_is_missing():
+        sf = StructField("name", StringType(), True)
+        assert _are_fields_shallow_equal(sf, None, False, False) is False
+
+
+def describe_compare_array_types():
+    def it_marks_the_element_line_as_unequal_when_one_side_is_missing():
+        lines: list[tuple[str, str, bool]] = []
+        _compare_array_types(ArrayType(StringType(), True), None, False, False, 0, lines)
+        assert len(lines) == 1
+        left, right, is_equal = lines[0]
+        assert "|-- element: string" in left
+        assert right == ""
+        assert is_equal is False
+
+
+def describe_compare_map_types():
+    def it_marks_the_key_and_value_lines_as_unequal_when_one_side_is_missing():
+        lines: list[tuple[str, str, bool]] = []
+        _compare_map_types(None, MapType(StringType(), IntegerType(), True), False, False, 0, lines)
+        assert len(lines) == 2
+        key_line, value_line = lines
+        assert key_line[0] == ""
+        assert "|-- key: string" in key_line[1]
+        assert key_line[2] is False
+        assert value_line[0] == ""
+        assert "|-- value: int" in value_line[1]
+        assert value_line[2] is False
+
+
+def describe_handle_schemas_not_equal():
+    def it_uses_a_tree_for_wide_schemas():
+        s1 = StructType([StructField("nums", ArrayType(IntegerType(), True), True)])
+        s2 = StructType([StructField("nums", ArrayType(StringType(), True), True)])
+        with pytest.raises(SchemasNotEqualError) as exc_info:
+            assert_schema_equality(s1, s2)
+        assert "|-- element: int" in str(exc_info.value)
+
+
+def describe_assert_schema_equality_full():
+    def it_throws_when_schema_lengths_differ_and_nullability_is_ignored():
+        s1 = StructType([StructField("name", StringType(), True)])
+        s2 = StructType([
+            StructField("name", StringType(), False),
+            StructField("age", IntegerType(), True),
+        ])
+        with pytest.raises(SchemasNotEqualError):
+            assert_schema_equality(s1, s2, ignore_nullable=True)
+
+
+def describe_are_structfields_equal_with_missing_fields():
+    def it_returns_true_when_both_are_none_and_nullability_is_ignored():
+        assert are_structfields_equal(None, None, ignore_nullability=True) is True
+
+    def it_returns_false_when_only_one_is_none_and_nullability_is_ignored():
+        sf = StructField("name", StringType(), True)
+        assert are_structfields_equal(sf, None, ignore_nullability=True) is False


### PR DESCRIPTION
Brings the test suite to 100% statement and branch coverage, and adds the tooling to keep it there.

| | `main` | current branch |
|---|---|---|
| Statements | 739 (59 missed) | 736 (0 missed) |
| Branches | 304 (37 partial) | 302 (0 partial) |
| Coverage | **89%** | **100%** |
| Tests | 185 passed | 252 passed, 1 xfailed |

The small drop in totals comes from the `flatten.py` import change described below.

## Tests added

Two new files:

- `tests/test_chispa.py` — the `Chispa` class had no direct coverage: default-format fallback, passing a `FormattingConfig` through untouched, converting a legacy dataclass, and both outcomes of `assert_df_equality`.
- `tests/test_number_helpers.py` — `nan_safe_equality` / `nan_safe_approx_equality`, including the `isnan` `TypeError` path and the boundary where the difference exactly equals the precision.

Extended:

- `test_row_comparer.py` — rewritten as parametrized cases with named ids. Adds missing-row handling, nan-vs-non-nan, and nested list/tuple comparison at differing lengths.
- `test_schema_comparer.py` — `print_schema_diff` in both output formats plus its unknown-format error, empty schemas, and tree-diff colouring for differing leaf types, nullability, and map key types.
- `test_dataframe_comparer.py` — `_contains_map_type` across nesting shapes, the zero-precision fallbacks in `assert_approx_df_equality`, and custom format objects reaching the output.
- `test_rows_comparer.py` — `assert_generic_rows_equality` with default and custom formats.
- `test_deprecated.py` — the two deprecated `*_ignore_nullable` helpers now assert their `DeprecationWarning`.
- `test_formats.py` / `test_formatting_config.py` — error paths for non-dict input, a list where a colour string is expected, and an invalid format type.

Assertions target observable behaviour — the actual ANSI codes in the error message, the specific tree line — rather than just "it raised".

## Source changes

Kept to the minimum needed to measure coverage — no logic is touched.

- `chispa/flatten.py`: the pyspark type imports moved out of the `TYPE_CHECKING` block to runtime imports, so the lines execute under coverage.
- Two `# pragma: no branch` markers on final `elif` arms whose fall-through is impossible (`flatten.py` map handling, `_compare_datatypes` map dispatch), each with the reason inline. `schema_comparer.py` is otherwise byte-identical to `main` — the marker is a comment; the branch it silences is unreachable because the enclosing `if` has already established the type is one of the three complex kinds, and the two preceding arms rule out the other two.

No behaviour changes.

## Tooling

- Coverage settings moved from the Make recipe into `pyproject.toml` (`[tool.coverage.run]` with `branch = true`, `[tool.coverage.report]` with `fail_under = 100`), so every entry point that passes `--cov` gets the same configuration.
- `make test` now reports `term-missing`, so a shortfall names the lines.
- New `coverage` CI job running `make test`. It pins `pyspark-version: 4.0.2` — the composite action defaults to 3.5.1, which no test job covers, and 4.0.2 is both exercised by the `test` matrix and shares its cache key with the Python 3.11 leg.

The nine-leg `test` matrix keeps running plain `pytest tests`. A pyspark-version quirk should surface as a test failure on the leg that has it, not as nine red coverage checks.

## For reviewers

**One xfail is intentional.** `it_throws_when_duplicate_column_names_hide_a_mismatch` is marked `xfail(strict=True)` and documents a real bug: `assert_basic_rows_equality` zips fields positionally but looks them up by name, so when a DataFrame has duplicate column names every lookup returns the first match and genuine differences go unreported. The test is written to pass once that is fixed. The same pattern exists in `assert_generic_rows_equality` and is not yet marked.

**Two further bugs found but deliberately left alone** — both reachable from the public API, both invisible to coverage, both better as their own PR:

1. `assert_df_equality` / `assert_approx_df_equality` mutate the caller's `transforms` list. Passing the same list to two calls with `ignore_column_order=True` leaves it holding two sort transforms.
2. `assert_basic_rows_equality` raises `AttributeError: 'NoneType' object has no attribute 'split'` instead of `DataFramesNotEqualError` when rows have different field counts, because `zip_longest` yields a `None` field name that is then used as a key.

**Three tests call private helpers with a `None` side on purpose.** `describe_compare_array_types`, `describe_compare_map_types`, and the both-missing case in `describe_are_fields_shallow_equal` pass arguments no public call path produces — the callers pair two same-kind types, and `zip_longest` never yields two `None`s. Those guards are therefore dead defensive code. They are covered here rather than deleted to keep this PR to tests; deleting them instead would remove ~16 statements and ~10 branches and reach 100% by subtraction. Happy to do that here if reviewers prefer.

## Verification

```
make test
```

Locally: 252 passed, 1 xfailed, 100% coverage; `pre-commit run -a` and `mypy chispa` clean. Note the local run is Python 3.14 / pyspark 4.0.0